### PR TITLE
fix(open): Open landing images + Host casing on B2B host

### DIFF
--- a/lib/surface-host.ts
+++ b/lib/surface-host.ts
@@ -75,6 +75,8 @@ export const OPEN_STATIC_ASSET_PREFIXES = [
   '/icon-',
   '/og/',
   '/open/og/',
+  /** Landing PNG/SVG lives under public/open/landing — must not hit /open/* → strip-/open redirect in middleware. */
+  '/open/landing/',
   '/fonts/',
   '/favicon',
 ] as const;

--- a/middleware.ts
+++ b/middleware.ts
@@ -52,7 +52,8 @@ const OPEN_NOT_FOUND_REWRITE = '/open/__not-a-b2b-route__';
 
 export function middleware(request: NextRequest) {
   // Canonical host: apex → www so referral sessionStorage + cookies stay on one origin (ref survives signup).
-  const host = request.headers.get('host')?.split(':')[0] ?? '';
+  // Lowercase: Host is case-insensitive; mismatched casing must not skip OPEN_HOSTS matching (would mis-route).
+  const host = request.headers.get('host')?.split(':')[0]?.toLowerCase() ?? '';
   if (host === 'pocketportfolio.app') {
     const url = request.nextUrl.clone();
     url.hostname = 'www.pocketportfolio.app';

--- a/tests/unit/surface-host.spec.ts
+++ b/tests/unit/surface-host.spec.ts
@@ -6,6 +6,11 @@ describe('isOpenStaticAssetPath', () => {
     expect(isOpenStaticAssetPath('/press/abba/abba-uk-black-business-show-820.webp')).toBe(true);
     expect(isOpenStaticAssetPath('/press/abba-lawal')).toBe(false);
   });
+
+  it('includes B2B landing art under /open/landing/ (public/open/landing)', () => {
+    expect(isOpenStaticAssetPath('/open/landing/hero-sovereign-layer.png')).toBe(true);
+    expect(isOpenStaticAssetPath('/open/landing/svg/privacy-architecture.svg')).toBe(true);
+  });
 });
 
 describe('isOpenSurfaceRoute', () => {


### PR DESCRIPTION
## Summary
- Exempt \/open/landing/*\ from middleware\u2019s \/open/*\ \u2192 strip-prefix redirect so PNG/SVG under \public/open/landing\ resolve (fixes broken hero art on www.openportfolio.co.uk).
- Lowercase \Host\ before OPEN_HOSTS checks.

## Test plan
- [ ] \
pm run lint\ / \
pm run typecheck\ (passed locally)
- [ ] \
px vitest run tests/unit/surface-host.spec.ts\
- [ ] After deploy: \curl -sI\ \https://www.openportfolio.co.uk/open/landing/hero-sovereign-layer.png\ \u2192 200, not 308 to \/landing/\

Made with [Cursor](https://cursor.com)