### PR TITLE
feat(seo): B2B vs B2C blog sitemap split

### DIFF
--- a/app/open/sitemap-static.ts
+++ b/app/open/sitemap-static.ts
@@ -5,14 +5,23 @@
  * middleware rewrite). Wealth-manager routes remain on the Pocket sitemap at
  * app/sitemap-static.ts.
  *
+ * Blog: hub plus every MDX post whose category is OPEN_BLOG_CATEGORIES (canonical
+ * on Open per app/blog/[slug]/page.tsx). Pocket-only posts stay on app/sitemap-blog.ts.
+ *
  * Routes mirror OPEN_ALIAS_ROUTES in lib/canonical-claims.ts.
  */
 
 import { MetadataRoute } from 'next';
+import {
+  loadBlogPostSitemapEntries,
+  partitionBlogPostsForSitemap,
+} from '../../lib/blog-sitemap-entries';
 import { OPEN_ALIAS_ROUTES, OPEN_URLS } from '../../lib/canonical-claims';
 
 export default async function openSitemapStatic(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
+  const entries = loadBlogPostSitemapEntries();
+  const { open: openBlogPosts } = partitionBlogPostsForSitemap(entries);
 
   return [
     {
@@ -33,6 +42,12 @@ export default async function openSitemapStatic(): Promise<MetadataRoute.Sitemap
       changeFrequency: 'daily',
       priority: 0.88,
     },
+    ...openBlogPosts.map((e) => ({
+      url: `${OPEN_URLS.home}/blog/${e.slug}`,
+      lastModified: e.lastModified,
+      changeFrequency: 'weekly' as const,
+      priority: 0.82,
+    })),
   ];
 }
 

--- a/app/open/sitemap.xml/route.ts
+++ b/app/open/sitemap.xml/route.ts
@@ -7,7 +7,7 @@ import openSitemapStatic from '../sitemap-static';
 export const dynamic = 'force-dynamic';
 
 /**
- * Dynamic B2B sitemap — SSOT is OPEN_ALIAS_ROUTES via openSitemapStatic().
+ * Dynamic B2B sitemap — OPEN_ALIAS_ROUTES + Open-category blog posts via openSitemapStatic().
  * Served at /open/sitemap.xml; Open-host requests rewrite /sitemap.xml here (middleware).
  */
 export async function GET() {

--- a/app/sitemap-blog.ts
+++ b/app/sitemap-blog.ts
@@ -1,18 +1,25 @@
 /**
  * OPERATION VELOCITY: Sitemap Segmentation
- * sitemap-blog.xml - Blog and content pages
+ * sitemap-blog.xml - Blog and content pages (Pocket / B2C canonical URLs only)
+ *
+ * Open-category posts (research, sovereign-engineering, how-to-in-tech) canonicalise
+ * on www.openportfolio.co.uk — those URLs live in app/open/sitemap-static.ts.
  */
 
 import { MetadataRoute } from 'next';
-import fs from 'fs';
-import path from 'path';
-import matter from 'gray-matter';
+import {
+  loadBlogPostSitemapEntries,
+  partitionBlogPostsForSitemap,
+} from '@/lib/blog-sitemap-entries';
 
 export default async function sitemapBlog(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://www.pocketportfolio.app';
   const now = new Date();
-  
+
   try {
+    const entries = loadBlogPostSitemapEntries();
+    const { pocket } = partitionBlogPostsForSitemap(entries);
+
     const blogPages: MetadataRoute.Sitemap = [
       {
         url: `${baseUrl}/blog`,
@@ -20,51 +27,19 @@ export default async function sitemapBlog(): Promise<MetadataRoute.Sitemap> {
         changeFrequency: 'weekly',
         priority: 0.7,
       },
+      ...pocket.map((e) => ({
+        url: `${baseUrl}/blog/${e.slug}`,
+        lastModified: e.lastModified,
+        changeFrequency: 'weekly' as const,
+        priority: 0.8,
+      })),
     ];
-    
-    // Add individual blog post URLs
-    try {
-      const postsDir = path.join(process.cwd(), 'content', 'posts');
-      if (fs.existsSync(postsDir)) {
-        const files = fs.readdirSync(postsDir);
-        const postFiles = files.filter(file => file.endsWith('.mdx'));
-        
-        for (const file of postFiles) {
-          try {
-            const filePath = path.join(postsDir, file);
-            const fileContents = fs.readFileSync(filePath, 'utf-8');
-            const { data } = matter(fileContents);
-            const slug = file.replace('.mdx', '');
-            
-            blogPages.push({
-              url: `${baseUrl}/blog/${slug}`,
-              lastModified: data.date ? new Date(data.date) : now,
-              changeFrequency: 'weekly',
-              priority: 0.8,
-            });
-          } catch (error) {
-            console.error(`[Sitemap Blog] Error processing blog post ${file}:`, error);
-          }
-        }
-      }
-    } catch (error) {
-      console.error('[Sitemap Blog] Error reading blog posts directory:', error);
-    }
-    
-    console.log(`[Sitemap Blog] Generated ${blogPages.length} blog pages`);
-    
+
+    console.log(`[Sitemap Blog] Pocket B2C: ${blogPages.length} URLs (hub + posts)`);
+
     return blogPages;
   } catch (error) {
     console.error('[Sitemap Blog] Error generating blog sitemap:', error);
     return [];
   }
 }
-
-
-
-
-
-
-
-
-

--- a/lib/blog-sitemap-entries.ts
+++ b/lib/blog-sitemap-entries.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared MDX scan for sitemap generation — one filesystem read, split by surface
+ * using OPEN_BLOG_CATEGORIES vs Pocket-only categories (canonical-claims).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { isOpenBlogCategory, isPocketBlogCategory } from './canonical-claims';
+
+export interface BlogPostSitemapEntry {
+  slug: string;
+  category: string | undefined;
+  lastModified: Date;
+}
+
+export function loadBlogPostSitemapEntries(): BlogPostSitemapEntry[] {
+  const postsDir = path.join(process.cwd(), 'content', 'posts');
+  if (!fs.existsSync(postsDir)) return [];
+
+  const now = new Date();
+  const entries: BlogPostSitemapEntry[] = [];
+
+  for (const file of fs.readdirSync(postsDir)) {
+    if (!file.endsWith('.mdx')) continue;
+    try {
+      const filePath = path.join(postsDir, file);
+      const fileContents = fs.readFileSync(filePath, 'utf-8');
+      const { data } = matter(fileContents);
+      const slug = file.replace(/\.mdx$/i, '');
+      entries.push({
+        slug,
+        category: typeof data.category === 'string' ? data.category : undefined,
+        lastModified: data.date ? new Date(data.date) : now,
+      });
+    } catch (err) {
+      console.error(`[blog-sitemap-entries] Error processing ${file}:`, err);
+    }
+  }
+
+  return entries;
+}
+
+export function partitionBlogPostsForSitemap(entries: BlogPostSitemapEntry[]): {
+  pocket: BlogPostSitemapEntry[];
+  open: BlogPostSitemapEntry[];
+} {
+  return {
+    pocket: entries.filter((e) => isPocketBlogCategory(e.category)),
+    open: entries.filter((e) => isOpenBlogCategory(e.category)),
+  };
+}

--- a/tests/unit/blog-sitemap-entries.spec.ts
+++ b/tests/unit/blog-sitemap-entries.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  partitionBlogPostsForSitemap,
+  type BlogPostSitemapEntry,
+} from '@/lib/blog-sitemap-entries';
+
+const base = (overrides: Partial<BlogPostSitemapEntry>): BlogPostSitemapEntry => ({
+  slug: 'x',
+  category: undefined,
+  lastModified: new Date('2026-01-01'),
+  ...overrides,
+});
+
+describe('partitionBlogPostsForSitemap', () => {
+  it('sends Open categories to open only', () => {
+    const { pocket, open } = partitionBlogPostsForSitemap([
+      base({ slug: 'a', category: 'research' }),
+      base({ slug: 'b', category: 'how-to-in-tech' }),
+      base({ slug: 'c', category: 'sovereign-engineering' }),
+    ]);
+    expect(pocket).toHaveLength(0);
+    expect(open.map((e) => e.slug).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('treats missing category as Pocket (deep-dive default)', () => {
+    const { pocket, open } = partitionBlogPostsForSitemap([
+      base({ slug: 'consumer', category: undefined }),
+    ]);
+    expect(open).toHaveLength(0);
+    expect(pocket).toHaveLength(1);
+    expect(pocket[0].slug).toBe('consumer');
+  });
+
+  it('keeps deep-dive on Pocket', () => {
+    const { pocket, open } = partitionBlogPostsForSitemap([
+      base({ slug: 'd', category: 'deep-dive' }),
+    ]);
+    expect(open).toHaveLength(0);
+    expect(pocket).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Open Portfolio sitemap (\www.openportfolio.co.uk/sitemap.xml\) now lists individual blog URLs for Open-category posts (\esearch\, \sovereign-engineering\, \how-to-in-tech\).
- Pocket sitemap blog chunk lists hub + Pocket-only posts only (no duplicate URLs for posts that redirect to Open).

## Test plan
- [x] \
pm run lint\, \
pm run typecheck\
- [x] \itest run tests/unit/blog-sitemap-entries.spec.ts\
- [ ] After merge: confirm Open sitemap XML includes \/blog/{slug}\ for substrate posts; Pocket blog chunk excludes those slugs

Made with [Cursor](https://cursor.com)