### PR TITLE
feat(growth-b2c): Pocket audit automation + glossary sitemap (production cutover)

### DIFF
--- a/app/sitemap-static.ts
+++ b/app/sitemap-static.ts
@@ -186,6 +186,24 @@ export default async function sitemapStatic(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/learn/realised-vs-unrealised`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/learn/dollar-cost-averaging`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/learn/json-finance`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
     // /learn/sovereign-stack and /learn/sovereign-finance migrated to Open Portfolio
     // (B2B developer surface). See app/open/sitemap-static.ts.
     // /architecture migrated to Open Portfolio (B2B developer surface).

--- a/docs/command/growth-b2c-audit-automated-probe.md
+++ b/docs/command/growth-b2c-audit-automated-probe.md
@@ -1,0 +1,39 @@
+# Pocket B2C growth audit — automated probe output
+
+_Generated 2026-05-17T12:03:54.019Z · production GET probes · https://www.pocketportfolio.app_
+
+## Phase 1 — Sitemap index (36-stream invariant)
+- Index HTTP: **200**
+- Child `<loc>` count: **36**
+- shard `sitemap-static-v3.xml`: ✓
+- shard `sitemap-imports-v3.xml`: ✓
+- shard `sitemap-tools-v3.xml`: ✓
+- shard `sitemap-blog-v3.xml`: ✓
+- Ticker shards: **16**/16
+- Risk shards: **16**/16
+- **Result:** PASS — 36 child streams
+
+## Phase 1 — Path-scoped Pocket → Open (redirect sanity)
+- `/architecture`: PASS (308 → https://www.openportfolio.co.uk/architecture)
+- `/press/abba-lawal`: PASS (308 → https://www.openportfolio.co.uk/press/abba-lawal)
+- `/` (manual): PASS (200)
+- `/press` (follow): PASS
+
+## Phase 1 — Sample Pocket money URLs (200 expected)
+- `/for/advisors`: **200** ✓
+- `/tools`: **200** ✓
+- `/learn/json-finance`: **200** ✓
+- `/cheapest-portfolio-tracker-no-subscription`: **200** ✓
+
+## Phase 0 — Manual / Growth-owned (NOT RUN HERE)
+- GSC property verification + Coverage dashboard snapshot
+- GA4 hostname-filter view + KPI baseline export (organic branded vs non-branded)
+- Release tag SSOT on `main` (git/Vercel)
+
+## Phase 2 — Repo hint (glossary vs static sitemap)
+- Cross-check `app/learn/*/page.tsx` (Pocket glossary slugs) vs `app/sitemap-static.ts` after each glossary ship; rebuild `npm run build:sitemaps` before indexing assertions.
+- Sovereign learn pillars intentionally Open-canonical — omitting them from Pocket static sitemap is expected.
+
+## Phase 3 — Manual
+- UK SERP grid + competitor velocity spreadsheet
+- GA4 exploration: verify advisor_tool funnel events in Explorations

--- a/docs/command/growth-b2c-audit-report-2026-05-17.md
+++ b/docs/command/growth-b2c-audit-report-2026-05-17.md
@@ -1,0 +1,90 @@
+---
+id: PP-GROWTH-B2C-AUDIT-REPORT-2026-05-17
+title: Pocket B2C growth programme — consolidated audit report (execution pass)
+status: TECH_EXECUTION_PASS
+programme_phase: PHASE_1_COMPLETE_TECH · PHASE_0_3_MANUAL_OUTSTANDING
+last_updated: 2026-05-17
+---
+
+# Pocket B2C growth programme — consolidated audit report
+
+This report records **what was executed from the repo vs production** versus **what remains Growth / Command manual work**. “Execute all phases” in engineering terms means: **automated verification**, **artifact updates**, and **explicit backlog** — not replacing Google Search Console, GA4 UI, or SERP tooling.
+
+---
+
+## Executive summary
+
+| Phase | Engineering execution | Status |
+|-------|----------------------|--------|
+| **0 — Baseline & governance** | GSC verification, GA4 hostname views, KPI CSV export, release tagging | **Outstanding** (requires Google accounts + Command) |
+| **1 — Technical SEO & index** | 36-stream sitemap PASS; redirect probes PASS; sample URLs 200 | **PASS** (see automated probe) |
+| **2 — Programmatic & glossary** | `/learn/json-finance` added to `app/sitemap-static.ts`; ticker/risk thin-content sampling | **Partial** — deploy `build:sitemaps`; thin-content audit backlog |
+| **3 — SERP / competitors / advisor** | Advisor funnel **instrumented in code** (`advisor_tool` analytics); SERP grid | **Partial** — instrument code ✓; GA4 dashboard validation + competitors manual |
+
+---
+
+## Automated probe (re-run anytime)
+
+```bash
+npm run audit:growth-b2c-pocket
+```
+
+Artifact: `docs/command/growth-b2c-audit-automated-probe.md` (overwritten each run).
+
+**Latest production highlights:**
+
+- `https://www.pocketportfolio.app/sitemap.xml` → **36** child sitemaps (`*-v3.xml`): static, imports, tools, blog, 16× tickers, 16× risk.
+- `/architecture` → **308** → `https://www.openportfolio.co.uk/architecture` (path-scoped migration ✓).
+- `/press/abba-lawal` → **308** → Open founder dossier ✓.
+- `/press` → **200** on Pocket ✓.
+- `/`, `/for/advisors`, `/tools`, `/learn/json-finance`, `/cheapest-portfolio-tracker-no-subscription` → **200** ✓.
+
+---
+
+## Phase 0 checklist (assign to Growth / Command)
+
+1. **P0-2 GSC:** Confirm Pocket property; submit `https://www.pocketportfolio.app/sitemap.xml`; export Coverage top issues (PDF or screenshot archive).
+2. **P0-3 GA4:** Explorer / report filtered by **hostname** `www.pocketportfolio.app`; exclude Open hosts from B2C KPIs.
+3. **P0-4 KPI baseline:** Export last 28d / last quarter: organic sessions (branded vs non-branded dimension), advisor_tool funnel counts.
+4. **P0-1 SSOT:** Tag `main` post-merge for audit trail (e.g. `audit-b2c-2026-05-17`).
+
+---
+
+## Phase 2 — Engineering backlog (prioritized)
+
+| Priority | Item |
+|----------|------|
+| **P0** | Ship `app/sitemap-static.ts` **json-finance** URL + run **`npm run build:sitemaps`** in CI/deploy so **production** `sitemap-static-v3.xml` includes it (until deploy, live HTML may exist without sitemap row). |
+| **P1** | Sample **50** random ticker + **50** risk URLs from sitemap shards; score thin/boilerplate; template tweaks if duplicate meta dominates. |
+| **P1** | Internal linking audit script (hub → leaf) — optional future automation. |
+| **P2** | Lighthouse / CrUX field data on money URLs (`npm run test:lighthouse` where CI permits). |
+
+---
+
+## Phase 3 — Advisor funnel (code verification)
+
+`app/for/advisors/AdvisorTool.tsx` emits **`advisor_tool`** events via `app/lib/analytics/tools.ts`:
+
+- Page view / funnel stage landing  
+- Interactions (`logo_upload`)  
+- Success + PDF **download_start**  
+- Errors (`invalid_file_type`, `pdf_generation_failed`, etc.)
+
+**Remainder:** Growth validates events in **GA4 DebugView / Explorations** and maps them to programme §2 “instrumentation maturity.”
+
+---
+
+## Phase 3 — SERP & competitors (manual)
+
+- Lock **approved keyword set** (5–10) using Search Console + Keyword Planner before chasing “private wealth terminal.”
+- Build competitor **content velocity** table (3–5 UK wealth-tech / tracker sites): publishing cadence, DR/backlinks snapshot (Ahrefs/Semrush if licensed).
+
+---
+
+## Programme SSOT
+
+Ratified scope & metrics: `docs/command/growth-b2c-pocket-market-acceleration-programme.md`
+
+---
+
+**Technical Lead sign-off (engineering slice):** Phase **1** automated gates **green** on production; Phase **0 / 3** marketing slices **not substitute-able by repo access**. Deploy glossary sitemap row + complete Phase 0 exports for full programme closure.

--- a/docs/command/growth-b2c-pocket-market-acceleration-programme.md
+++ b/docs/command/growth-b2c-pocket-market-acceleration-programme.md
@@ -1,0 +1,92 @@
+---
+id: PP-GROWTH-B2C-PROGRAMME-2026-05
+title: Pocket B2C — market acceleration & growth audit programme (ratified)
+status: RATIFIED_WITH_AMENDMENTS
+programme_phase: TECH_EXECUTION_PASS_2026_05_17
+last_updated: 2026-05-17
+---
+
+# Pocket B2C growth audit — Unified Command ratification (with technical amendments)
+
+This document is the **single SSOT** for the approved **Pocket-only** growth audit programme. It incorporates **mandatory corrections** from Technical Lead review so squads do not mis-test routing or sign impossible success criteria.
+
+---
+
+## 1. Binding technical clarification (do not paraphrase away)
+
+**Primary Pocket canonical traffic stays on Pocket.**
+
+- **`www.pocketportfolio.app`** (and apex consolidation to `www` / HTTPS on **Pocket hosts only**) is the normal consumer surface.
+- Migration to Open is **`path-scoped`**: `next.config.js` emits **301** from Pocket hosts to **`https://www.openportfolio.co.uk{path}`** **only** for paths listed in **`OPEN_ALIAS_POCKET_TO_OPEN_PATHS`** (synced with B2B aliasing; **`/press`** excluded for the consumer hub).
+
+**Auditors must not** describe this as “primary Pocket canonical traffic migrating to Open.” That false framing invalidates crawl and GSC interpretation.
+
+---
+
+## 2. Success metrics — revised numeric definitions (Command-approved intent, TL-precise wording)
+
+| Goal | Definition | Notes |
+|------|------------|--------|
+| **Organic discovery** | **Δ non-branded organic sessions (Pocket hostname)** ≥ **+35%** quarter-over-quarter | **Guardrails:** (a) define segment in GA4 with **`hostname = www.pocketportfolio.app`**; (b) exclude Open hosts; (c) enforce **minimum monthly session floor** (e.g. 500+) before QoQ is scored, or report confidence interval; (d) **fallback milestone:** +15% QoQ **plus** agreed leading-indicator wins (e.g. impressions on target queries) if baseline is volatile. |
+| **SERP placement** | **Top 5 (UK)** for an **agreed primary intent term** | **Before locking:** validate query in Search Console / Keyword Planner (volume, SERP type, whether compound queries outperform “private wealth terminal”). Maintain a **small approved keyword set** (5–10); primary term is chosen from that list, not assumed. |
+| **Advisor funnel** | **100% instrumentation maturity** — every defined step in `/for/advisors` fires a named analytics event (landing → engagement → PDF/tool completion as applicable), with **dashboard verification** | **Not** “100% lead conversion” (impossible). Optional **Phase 2 CVR target** is set **after** baseline conversion is measured (numeric, benchmarked). |
+
+---
+
+## 3. Scope boundary
+
+- **Pocket-only** for routine audit work: **`pocketportfolio.app`** / **`www.pocketportfolio.app`**.
+- **Open Portfolio cross-check** only via **formal engineering escalation** (e.g. citation conflict, unexpected shared equity on `/press` or redirects).
+
+---
+
+## 4. Ownership matrix — Phase 0 (Week 1)
+
+| ID | Task | Owner |
+|----|------|--------|
+| **P0-1** | Production SSOT: releases tagged from **`main`**; deploy pipeline matches canonical repo state | Eng Lead / DevOps |
+| **P0-2** | GSC: Pocket property verification; **`https://www.pocketportfolio.app/sitemap.xml`** submitted; top issues logged | Growth / SEO |
+| **P0-3** | GA4: hostname / reporting view isolates **Pocket** from **Open** traffic | Growth / Data |
+| **P0-4** | KPI baseline doc: branded vs non-branded organic, advisor funnel events (once instrumented) | Command + Growth |
+
+**Phase 0 exit:** baseline captured + KPI definitions signed; Phase 1 crawl/index work authorised.
+
+---
+
+## 5. Linear epic (reference structure)
+
+**Epic:** `[GROWTH-B2C] Pocket Portfolio market dominance & indexation audit`
+
+### Story 1 — `[GROWTH-B2C-01]` Technical SEO & 36-stream index validation (P0)
+
+- Confirm **`https://www.pocketportfolio.app/sitemap.xml`** lists **36** child streams (static, imports, tools, blog, 16× tickers, 16× risks) per `scripts/build-static-sitemaps.ts` / production behaviour.
+- Production crawl: document **4xx/5xx** and **bad redirect chains** on core money URLs.
+- Rich Results / structured data: **representative sample** of consumer templates passes validation (do not assert “every page flawless” unless inventory is explicitly in scope).
+
+### Story 2 — `[GROWTH-B2C-02]` Programmatic glossary & content completeness (P0)
+
+- Ticker/risk template sample for thin/boilerplate risk.
+- Confirm glossary URLs staged for spider discovery — including **`/learn/realised-vs-unrealised`** and **`/learn/dollar-cost-averaging`** in **`app/sitemap-static.ts`** (artifact parity).
+- Internal linking map: hubs (`/tools`, import surfaces, `/learn`) → programmatic leaves.
+
+### Story 3 — `[GROWTH-B2C-03]` Advisor funnel & SERP competitiveness (P1)
+
+- Competitor content velocity snapshot (3–5 UK peers).
+- Full **`/for/advisors`** funnel instrumentation per §2.
+- AEO spot-check: Pocket messaging consistency with **local-first / zero warehouse ledger** positioning.
+
+---
+
+## 6. In-repo engineering artefacts (already aligned)
+
+- Dual-surface routing: **`middleware.ts`**, **`next.config.js`**, **`lib/canonical-claims.ts`** (`OPEN_ALIAS_ROUTES`, Pocket→Open path list).
+- Pocket **36-stream** sitemap build; Open dynamic sitemap + Open-category blog URLs (**`lib/blog-sitemap-entries.ts`**).
+- Split **`llms.txt`** manifests (Pocket vs Open) and CI drift guard where configured.
+
+---
+
+## 7. Technical Lead operational verdict
+
+Programme **approved** for execution **with §1–2 amendments binding**. Phase **0** is **authorised**. Squads assign Linear keys and begin baseline ingestion.
+
+**Build for purpose. Verify on artifact. Reciprocate the signal.**

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "preview": "next start -p 3001",
     "typecheck": "tsc --noEmit",
     "audit:open-404": "node scripts/audit-open-404.mjs",
+    "audit:growth-b2c-pocket": "node scripts/growth-b2c-pocket-audit.mjs",
     "generate:open-landing-visuals": "node scripts/generate-open-landing-visuals.mjs",
     "lint": "next lint",
     "lint:fix": "next lint --fix",

--- a/scripts/growth-b2c-pocket-audit.mjs
+++ b/scripts/growth-b2c-pocket-audit.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Pocket B2C growth programme — technical verification pass (production probes).
+ * Does not replace GSC, GA4, CrUX, or competitive SERP research.
+ *
+ * Usage: node scripts/growth-b2c-pocket-audit.mjs
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+const BASE = 'https://www.pocketportfolio.app';
+const UA = { 'user-agent': 'PocketGrowthAudit/1.1 (+engineering-local)' };
+
+async function probeManual(url) {
+  const res = await fetch(url, { redirect: 'manual', headers: UA });
+  const loc = res.headers.get('location') || '';
+  return { status: res.status, location: loc };
+}
+
+async function probeFollow(url) {
+  const res = await fetch(url, { redirect: 'follow', headers: UA });
+  return res.status;
+}
+
+async function main() {
+  const lines = [];
+  const push = (s) => {
+    lines.push(s);
+    console.log(s);
+  };
+
+  push('# Pocket B2C growth audit — automated probe output');
+  push('');
+  push(`_Generated ${new Date().toISOString()} · production GET probes · ${BASE}_`);
+  push('');
+  push('## Phase 1 — Sitemap index (36-stream invariant)');
+  const indexRes = await fetch(`${BASE}/sitemap.xml`, { headers: UA });
+  const indexXml = await indexRes.text();
+  const locs = [...indexXml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1].trim());
+  push(`- Index HTTP: **${indexRes.status}**`);
+  push(`- Child \`<loc>\` count: **${locs.length}**`);
+  const needPrefix = [
+    'sitemap-static-v3.xml',
+    'sitemap-imports-v3.xml',
+    'sitemap-tools-v3.xml',
+    'sitemap-blog-v3.xml',
+  ];
+  let ok = indexRes.status === 200 && locs.length === 36;
+  for (const p of needPrefix) {
+    const hit = locs.some((l) => l.endsWith(p));
+    push(`- shard \`${p}\`: ${hit ? '✓' : '✗ MISSING'}`);
+    if (!hit) ok = false;
+  }
+  const tc = locs.filter((l) => /sitemap-tickers-\d+-v3\.xml$/.test(l)).length;
+  const rc = locs.filter((l) => /sitemap-risk-\d+-v3\.xml$/.test(l)).length;
+  push(`- Ticker shards: **${tc}**/16`);
+  push(`- Risk shards: **${rc}**/16`);
+  if (tc !== 16 || rc !== 16) ok = false;
+  push(`- **Result:** ${ok ? 'PASS — 36 child streams' : 'FAIL — count mismatch'}`);
+  push('');
+
+  push('## Phase 1 — Path-scoped Pocket → Open (redirect sanity)');
+  const arch = await probeManual(`${BASE}/architecture`);
+  const archOk =
+    arch.status >= 300 &&
+    arch.status < 400 &&
+    arch.location.includes('www.openportfolio.co.uk/architecture');
+  push(`- \`/architecture\`: ${archOk ? 'PASS' : 'FAIL'} (${arch.status} → ${arch.location || 'no Location'})`);
+
+  const founder = await probeManual(`${BASE}/press/abba-lawal`);
+  const founderOk =
+    founder.status >= 300 &&
+    founder.status < 400 &&
+    founder.location.includes('www.openportfolio.co.uk');
+  push(`- \`/press/abba-lawal\`: ${founderOk ? 'PASS' : 'FAIL'} (${founder.status} → ${founder.location || '—'})`);
+
+  const home = await probeManual(`${BASE}/`);
+  const homeOk = home.status === 200 || (home.status >= 300 && home.location.includes('pocketportfolio.app'));
+  push(`- \`/\` (manual): ${homeOk ? 'PASS' : 'FAIL'} (${home.status})`);
+
+  const press = await probeFollow(`${BASE}/press`);
+  push(`- \`/press\` (follow): ${press === 200 ? 'PASS' : `FAIL (${press})`}`);
+
+  push('');
+  push('## Phase 1 — Sample Pocket money URLs (200 expected)');
+  for (const p of ['/for/advisors', '/tools', '/learn/json-finance', '/cheapest-portfolio-tracker-no-subscription']) {
+    const st = await probeFollow(`${BASE}${p}`);
+    push(`- \`${p}\`: **${st}** ${st === 200 ? '✓' : '⚠'}`);
+  }
+
+  push('');
+  push('## Phase 0 — Manual / Growth-owned (NOT RUN HERE)');
+  push('- GSC property verification + Coverage dashboard snapshot');
+  push('- GA4 hostname-filter view + KPI baseline export (organic branded vs non-branded)');
+  push('- Release tag SSOT on `main` (git/Vercel)');
+
+  push('');
+  push('## Phase 2 — Repo hint (glossary vs static sitemap)');
+  push('- Cross-check `app/learn/*/page.tsx` (Pocket glossary slugs) vs `app/sitemap-static.ts` after each glossary ship; rebuild `npm run build:sitemaps` before indexing assertions.');
+  push('- Sovereign learn pillars intentionally Open-canonical — omitting them from Pocket static sitemap is expected.');
+
+  push('');
+  push('## Phase 3 — Manual');
+  push('- UK SERP grid + competitor velocity spreadsheet');
+  push('- GA4 exploration: verify advisor_tool funnel events in Explorations');
+
+  const outFile = path.join(ROOT, 'docs/command/growth-b2c-audit-automated-probe.md');
+  await fs.writeFile(outFile, lines.join('\n'), 'utf8');
+  console.log(`\n[audit] Wrote ${outFile}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Pocket static sitemap: add `/learn/realised-vs-unrealised`, `/learn/dollar-cost-averaging`, `/learn/json-finance` for B2C indexation parity.
- `npm run audit:growth-b2c-pocket`: production probes (36-stream index, Pocket→Open redirects, core money URLs).
- Command artefacts: programme SSOT + audit report + probe snapshot under `docs/command/growth-b2c-*` only.

## Scope

B2C growth programme commit only; other local `docs/command/*` files were **not** included in this commit.

## Post-merge

- Production build runs `build:sitemaps` → refreshed `sitemap-static-v3.xml`.
- Optional: resubmit Pocket sitemap in GSC.

## Test plan

- [x] `npm run lint` / `npm run typecheck`
- [ ] CI green on PR
