### PR TITLE
fix(newsroom): literal revalidate for Vercel build

### DIFF
--- a/app/api/newsroom/route.ts
+++ b/app/api/newsroom/route.ts
@@ -3,7 +3,8 @@ import { NEWSROOM_CACHE_SECONDS } from '@/lib/newsroom/constants';
 import { getNewsroomPayload } from '@/lib/newsroom/store';
 
 export const runtime = 'nodejs';
-export const revalidate = NEWSROOM_CACHE_SECONDS;
+/** Next.js requires a literal — keep in sync with NEWSROOM_CACHE_SECONDS in lib/newsroom/constants.ts */
+export const revalidate = 1800;
 
 export async function GET() {
   try {

--- a/app/newsroom/page.tsx
+++ b/app/newsroom/page.tsx
@@ -2,7 +2,6 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import ProductionNavbar from '../components/marketing/ProductionNavbar';
 import NewsRoomBriefingCard from '../components/newsroom/NewsRoomBriefingCard';
-import { NEWSROOM_CACHE_SECONDS } from '@/lib/newsroom/constants';
 import { getNewsroomPayload } from '@/lib/newsroom/store';
 import { SURFACE_CROSS_LINKS } from '@/lib/canonical-claims';
 
@@ -15,7 +14,8 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = NEWSROOM_CACHE_SECONDS;
+/** Next.js requires a literal — keep in sync with NEWSROOM_CACHE_SECONDS (1800) in lib/newsroom/constants.ts */
+export const revalidate = 1800;
 
 export default async function NewsroomPage() {
   const payload = await getNewsroomPayload();

--- a/lib/newsroom/constants.ts
+++ b/lib/newsroom/constants.ts
@@ -4,7 +4,10 @@ export const MAX_BRIEFING_AGE_HOURS = 72;
 /** KV / edge payload older than this triggers a live re-ingest on read. */
 export const STALE_PAYLOAD_MAX_AGE_HOURS = 4;
 
-/** API + Next cache TTL (seconds) — keep in sync with cron cadence. */
+/**
+ * API + Next cache TTL (seconds) — keep in sync with cron cadence.
+ * Route/page `export const revalidate` must use literal `1800` (Next.js build constraint).
+ */
 export const NEWSROOM_CACHE_SECONDS = 1800;
 
 /** Vercel KV TTL (seconds) — slightly longer than cron interval. */


### PR DESCRIPTION
Fixes production build: Next.js requires export const revalidate to be a static literal (1800), not NEWSROOM_CACHE_SECONDS import. Verified locally with npm run build.

Made with [Cursor](https://cursor.com)