### PR TITLE
fix(seo): permanent redirect Open apex hosts to canonical www

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -61,7 +61,10 @@ export function middleware(request: NextRequest) {
   }
 
   // Open Portfolio (B2B surface): path-fork before any P.-specific logic runs.
-  // Any O. host other than the canonical apex 307-redirects to www.openportfolio.co.uk.
+  // Any O. host other than the canonical hostname uses a permanent redirect (308)
+  // to www.openportfolio.co.uk so crawlers consolidate duplicates (GSC:
+  // "Duplicate without user-selected canonical" on apex). Temporary 307 here would
+  // override next.config permanent redirects because middleware runs first on Vercel.
   // The canonical host gets an internal rewrite to /open/<path> so the Next.js
   // route group at app/open/ handles the request with O. chrome + metadata.
   if (isOpenHost(host)) {
@@ -69,7 +72,7 @@ export function middleware(request: NextRequest) {
     if (host !== openCanonical) {
       const url = request.nextUrl.clone();
       url.hostname = openCanonical;
-      return NextResponse.redirect(url, 307);
+      return NextResponse.redirect(url, 308);
     }
 
     const pathname = request.nextUrl.pathname;


### PR DESCRIPTION
## Summary

- Open B2B hosts: apex `openportfolio.co.uk`, `openportfolio.uk`, and non-canonical `www.openportfolio.uk` previously hit middleware **307** to `www.openportfolio.co.uk`. Middleware runs **before** `next.config.js` **301** rules on Vercel, so crawlers saw a **temporary** hop — weak duplicate consolidation and GSC **Duplicate without user-selected canonical** on the apex URL.
- Switched that hop to **308 Permanent Redirect** so Google consolidates on `https://www.openportfolio.co.uk/` with the same signals as HTML `rel=canonical`.

## Post-merge

1. URL Inspection on apex URL — expect **308** to www.
2. GSC → affected report → **Validate fix** after deploy settles.

## Test plan

- [ ] `curl -sI https://openportfolio.co.uk/` shows **308** (or 301) with `Location: https://www.openportfolio.co.uk/`
- [ ] `curl -sI https://www.openportfolio.co.uk/` still **200**
- [ ] Open smoke: hero + `/architecture` on www
