### PR TITLE
fix(newsroom): live publisher RSS and real article URLs

### DIFF
--- a/app/api/cron/newsroom-ingest/route.ts
+++ b/app/api/cron/newsroom-ingest/route.ts
@@ -20,6 +20,21 @@ export async function GET(request: Request) {
     const persisted = await setNewsroomPayload(payload);
     revalidateTag('newsroom');
 
+    if (payload.briefings.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Ingest returned zero briefings — KV not updated',
+          count: 0,
+          source: payload.source,
+          persisted: false,
+          updatedAt: payload.updatedAt,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
     return NextResponse.json({
       success: true,
       count: payload.briefings.length,

--- a/app/components/CommunityContent.tsx
+++ b/app/components/CommunityContent.tsx
@@ -31,7 +31,9 @@ export default function CommunityContent() {
 
   const briefings = payload?.briefings ?? [];
   const updatedAt = payload?.updatedAt ?? new Date().toISOString();
-  const isLiveFeed = payload?.source === 'google-news-rss' || payload?.source === 'kv-cache';
+  const isLiveFeed =
+    briefings.length > 0 &&
+    (payload?.source === 'google-news-rss' || payload?.source === 'kv-cache');
 
   const primaryStyle: React.CSSProperties = {
     padding: '12px 24px',
@@ -127,7 +129,9 @@ export default function CommunityContent() {
             <p style={{ fontSize: '12px', color: 'var(--muted)', ...MONO }}>
               {loading
                 ? 'Loading market briefings…'
-                : `Updated ${new Date(updatedAt).toLocaleDateString('en-GB', { dateStyle: 'medium' })} · ${isLiveFeed ? 'live RSS' : 'editorial fallback'}`}
+                : briefings.length === 0
+                  ? 'Briefings updating — no live feed yet'
+                  : `Updated ${new Date(updatedAt).toLocaleDateString('en-GB', { dateStyle: 'medium' })} · live RSS`}
             </p>
           </div>
 
@@ -139,6 +143,20 @@ export default function CommunityContent() {
               marginBottom: '36px',
             }}
           >
+            {!loading && briefings.length === 0 ? (
+              <p
+                style={{
+                  gridColumn: '1 / -1',
+                  textAlign: 'center',
+                  color: 'var(--muted)',
+                  fontSize: '14px',
+                  padding: '32px 16px',
+                  ...MONO,
+                }}
+              >
+                Briefings are updating — we only show live publisher headlines, not placeholder copy.
+              </p>
+            ) : null}
             {loading
               ? Array.from({ length: 3 }).map((_, i) => (
                   <div

--- a/app/newsroom/page.tsx
+++ b/app/newsroom/page.tsx
@@ -68,9 +68,25 @@ export default async function NewsroomPage() {
               fontFamily: 'ui-monospace, Menlo, monospace',
             }}
           >
-            Last updated {new Date(payload.updatedAt).toLocaleString('en-GB')} · source: {payload.source}
+            {payload.briefings.length === 0
+              ? 'Briefings updating — no live feed yet'
+              : `Last updated ${new Date(payload.updatedAt).toLocaleString('en-GB')} · live RSS`}
           </p>
         </header>
+
+        {payload.briefings.length === 0 ? (
+          <p
+            style={{
+              textAlign: 'center',
+              color: 'var(--muted)',
+              fontFamily: 'ui-monospace, Menlo, monospace',
+              fontSize: '14px',
+              marginBottom: '40px',
+            }}
+          >
+            Publisher feeds are being refreshed. Cron ingest runs every 4 hours.
+          </p>
+        ) : null}
 
         <div
           style={{

--- a/lib/newsroom/feeds.ts
+++ b/lib/newsroom/feeds.ts
@@ -1,0 +1,26 @@
+import type { NewsroomCategory } from './types';
+
+export interface CuratedNewsFeed {
+  url: string;
+  label: string;
+  preferredCategory: NewsroomCategory;
+}
+
+/** Publisher RSS with direct article URLs (not Google News redirects). */
+export const CURATED_NEWS_FEEDS: CuratedNewsFeed[] = [
+  {
+    url: 'https://www.fca.org.uk/news/rss.xml',
+    label: 'FCA',
+    preferredCategory: 'REGULATORY COMPLIANCE',
+  },
+  {
+    url: 'https://www.moneymarketing.co.uk/feed/',
+    label: 'Money Marketing',
+    preferredCategory: 'MARKET INTELLIGENCE',
+  },
+  {
+    url: 'https://thefintechtimes.com/feed/',
+    label: 'The Fintech Times',
+    preferredCategory: 'WEALTH-TECH SCALING',
+  },
+];

--- a/lib/newsroom/ingest.ts
+++ b/lib/newsroom/ingest.ts
@@ -6,17 +6,17 @@ import {
 } from './categories';
 import { MAX_BRIEFING_AGE_HOURS } from './constants';
 import { CATEGORY_ART_URL, publisherLogoUrl } from './category-art';
+import { CURATED_NEWS_FEEDS } from './feeds';
 import { parseRssFeed, type ParsedRssItem } from './parse-rss';
+import { resolveBriefingHref } from './resolve-href';
 import type { NewsroomBriefing, NewsroomCategory, NewsroomPayload } from './types';
-import { SEED_NEWSROOM_PAYLOAD } from './seed';
 
-const RSS_QUERIES: { query: string; preferredCategory?: NewsroomCategory }[] = [
+/** Supplemental Google News queries when curated feeds are thin. */
+const GOOGLE_NEWS_QUERIES: { query: string; preferredCategory?: NewsroomCategory }[] = [
   { query: 'FCA consumer duty UK wealth management', preferredCategory: 'REGULATORY COMPLIANCE' },
-  { query: 'UK financial advisor compliance regulation', preferredCategory: 'REGULATORY COMPLIANCE' },
-  { query: 'wealth tech fintech UK platform', preferredCategory: 'WEALTH-TECH SCALING' },
-  { query: 'portfolio software local first', preferredCategory: 'WEALTH-TECH SCALING' },
-  { query: 'UK asset allocation wealth managers', preferredCategory: 'MARKET INTELLIGENCE' },
-  { query: 'financial markets UK advisers', preferredCategory: 'MARKET INTELLIGENCE' },
+  { query: 'UK financial advisor regulation', preferredCategory: 'REGULATORY COMPLIANCE' },
+  { query: 'wealth tech fintech UK', preferredCategory: 'WEALTH-TECH SCALING' },
+  { query: 'UK asset allocation advisers', preferredCategory: 'MARKET INTELLIGENCE' },
 ];
 
 const PER_CATEGORY = 2;
@@ -38,17 +38,18 @@ function slugify(input: string): string {
 function snippetFromTitle(title: string, source: string): string {
   const base = title.trim();
   if (base.length >= 120) return `${base.slice(0, 117)}…`;
-  return `${base} — reported via ${source}.`;
+  return `${base} — ${source}`;
 }
 
 function toBriefing(item: ParsedRssItem, category: NewsroomCategory): NewsroomBriefing {
+  const href = resolveBriefingHref(item);
   return {
-    id: slugify(`${category}-${item.title}`),
+    id: slugify(`${category}-${item.title}-${href}`),
     category,
     title: item.title,
     snippet: snippetFromTitle(item.title, item.source),
     tags: tagsForCategory(category),
-    href: item.url,
+    href,
     source: item.source,
     publishedAt: item.publishedAt,
     imageUrl: item.image,
@@ -58,41 +59,70 @@ function toBriefing(item: ParsedRssItem, category: NewsroomCategory): NewsroomBr
   };
 }
 
-async function fetchGoogleNewsRss(query: string): Promise<ParsedRssItem[]> {
-  const newsUrl = `https://news.google.com/rss/search?q=${encodeURIComponent(query)}&hl=en-GB&gl=GB&ceid=GB:en`;
-  const response = await fetch(newsUrl, {
+async function fetchRss(url: string, label: string): Promise<ParsedRssItem[]> {
+  const response = await fetch(url, {
     headers: {
       'User-Agent': 'Mozilla/5.0 (PocketPortfolio/Newsroom)',
-      Accept: 'application/rss+xml,text/xml,*/*',
+      Accept: 'application/rss+xml,application/xml,text/xml,*/*',
     },
     cache: 'no-store',
   });
-  if (!response.ok) return [];
+  if (!response.ok) {
+    console.warn(`[newsroom] RSS ${label} HTTP ${response.status}`);
+    return [];
+  }
   const xml = await response.text();
-  return parseRssFeed(xml, 'Google News');
+  return parseRssFeed(xml, label);
 }
 
-/** Fetch UK wealth/fintech RSS lanes and balance across three institutional categories. */
-export async function ingestNewsroomBriefings(): Promise<NewsroomPayload> {
-  const results = await Promise.all(
-    RSS_QUERIES.map(async ({ query, preferredCategory }) => {
-      const items = await fetchGoogleNewsRss(query);
-      return items.map((item) => ({
-        item,
-        category: preferredCategory ?? classifyNewsroomCategory(item.title, item.source),
-      }));
-    }),
-  );
+async function fetchGoogleNewsRss(query: string): Promise<ParsedRssItem[]> {
+  const newsUrl = `https://news.google.com/rss/search?q=${encodeURIComponent(query)}&hl=en-GB&gl=GB&ceid=GB:en`;
+  return fetchRss(newsUrl, 'Google News');
+}
 
-  const byUrl = new Map<string, { item: ParsedRssItem; category: NewsroomCategory }>();
-  for (const entry of results.flat()) {
-    const { item } = entry;
+function collectCandidates(
+  items: ParsedRssItem[],
+  preferredCategory: NewsroomCategory | undefined,
+  byHref: Map<string, { item: ParsedRssItem; category: NewsroomCategory }>,
+): void {
+  for (const item of items) {
     if (!isFreshEnough(item.publishedAt)) continue;
     if (!isRelevantWealthHeadline(item.title, item.source)) continue;
-    if (!byUrl.has(item.url)) byUrl.set(item.url, entry);
+    const href = resolveBriefingHref(item);
+    if (byHref.has(href)) continue;
+    const category = preferredCategory ?? classifyNewsroomCategory(item.title, item.source);
+    byHref.set(href, { item, category });
+  }
+}
+
+/** Fetch curated publisher RSS + supplemental Google News; balance three lanes. */
+export async function ingestNewsroomBriefings(): Promise<NewsroomPayload> {
+  const byHref = new Map<string, { item: ParsedRssItem; category: NewsroomCategory }>();
+
+  const curatedResults = await Promise.all(
+    CURATED_NEWS_FEEDS.map(async (feed) => ({
+      feed,
+      items: await fetchRss(feed.url, feed.label),
+    })),
+  );
+
+  for (const { feed, items } of curatedResults) {
+    collectCandidates(items, feed.preferredCategory, byHref);
   }
 
-  const sorted = [...byUrl.values()].sort(
+  if (byHref.size < MAX_BRIEFINGS) {
+    const googleResults = await Promise.all(
+      GOOGLE_NEWS_QUERIES.map(async ({ query, preferredCategory }) => ({
+        preferredCategory,
+        items: await fetchGoogleNewsRss(query),
+      })),
+    );
+    for (const { items, preferredCategory } of googleResults) {
+      collectCandidates(items, preferredCategory, byHref);
+    }
+  }
+
+  const sorted = [...byHref.values()].sort(
     (a, b) => new Date(b.item.publishedAt).getTime() - new Date(a.item.publishedAt).getTime(),
   );
 
@@ -102,25 +132,19 @@ export async function ingestNewsroomBriefings(): Promise<NewsroomPayload> {
     'MARKET INTELLIGENCE': [],
   };
 
-  for (const { item } of sorted) {
+  for (const { item, category: preferred } of sorted) {
     const lane = classifyNewsroomCategory(item.title, item.source);
-    if (buckets[lane].length >= PER_CATEGORY) continue;
-    if (buckets[lane].some((b) => b.href === item.url)) continue;
-    buckets[lane].push(toBriefing(item, lane));
+    const target = buckets[lane].length < PER_CATEGORY ? lane : preferred;
+    if (buckets[target].length >= PER_CATEGORY) continue;
+    if (buckets[target].some((b) => b.href === resolveBriefingHref(item))) continue;
+    buckets[target].push(toBriefing(item, target));
   }
 
-  let briefings = Object.values(buckets).flat().slice(0, MAX_BRIEFINGS);
-
-  if (briefings.length < 3) {
-    return {
-      ...SEED_NEWSROOM_PAYLOAD,
-      updatedAt: new Date().toISOString(),
-    };
-  }
+  const briefings = Object.values(buckets).flat().slice(0, MAX_BRIEFINGS);
 
   return {
     updatedAt: new Date().toISOString(),
     briefings,
-    source: 'google-news-rss',
+    source: briefings.length > 0 ? 'google-news-rss' : 'unavailable',
   };
 }

--- a/lib/newsroom/parse-rss.ts
+++ b/lib/newsroom/parse-rss.ts
@@ -40,6 +40,12 @@ function extractSourceSiteUrl(xml: string): string | null {
   return match?.[1]?.trim() || null;
 }
 
+function parsePubDate(raw: string): string {
+  if (!raw.trim()) return new Date().toISOString();
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
+}
+
 export function parseRssFeed(xml: string, feedLabel: string): ParsedRssItem[] {
   const items: ParsedRssItem[] = [];
   const parts = xml.split(/<item>/i).slice(1).map((x) => x.split(/<\/item>/i)[0]);
@@ -66,7 +72,7 @@ export function parseRssFeed(xml: string, feedLabel: string): ParsedRssItem[] {
       url: link,
       source: extractText(item, 'source') || extractDomain(link) || feedLabel,
       sourceSiteUrl,
-      publishedAt: publishedAt ? new Date(publishedAt).toISOString() : new Date().toISOString(),
+      publishedAt: parsePubDate(publishedAt),
       image: extractImage(item),
     });
   }

--- a/lib/newsroom/resolve-href.ts
+++ b/lib/newsroom/resolve-href.ts
@@ -1,0 +1,32 @@
+import type { ParsedRssItem } from './parse-rss';
+
+const GOOGLE_NEWS_ARTICLE = /news\.google\.com\/rss\/articles\//i;
+
+/** Prefer publisher article URLs; Google News items link to a title-specific search. */
+export function resolveBriefingHref(item: ParsedRssItem): string {
+  const link = item.url.trim();
+  if (!link) {
+    return publisherFallback(item);
+  }
+
+  if (!GOOGLE_NEWS_ARTICLE.test(link)) {
+    return link;
+  }
+
+  try {
+    const url = new URL(link);
+    const direct = url.searchParams.get('url');
+    if (direct && direct.startsWith('http')) return direct;
+  } catch {
+    /* keep resolving */
+  }
+
+  const q = encodeURIComponent(item.title.trim());
+  return `https://news.google.com/search?q=${q}&hl=en-GB&gl=GB&ceid=GB:en`;
+}
+
+function publisherFallback(item: ParsedRssItem): string {
+  if (item.sourceSiteUrl?.startsWith('http')) return item.sourceSiteUrl;
+  const q = encodeURIComponent(item.title.trim());
+  return `https://news.google.com/search?q=${q}&hl=en-GB&gl=GB&ceid=GB:en`;
+}

--- a/lib/newsroom/seed.ts
+++ b/lib/newsroom/seed.ts
@@ -1,3 +1,4 @@
+/** Dev/docs only — never returned by getNewsroomPayload() in production. */
 import type { NewsroomBriefing, NewsroomPayload } from './types';
 import { CATEGORY_MEDIA } from './categories';
 import { CATEGORY_ART_URL, publisherLogoUrl } from './category-art';

--- a/lib/newsroom/store.ts
+++ b/lib/newsroom/store.ts
@@ -8,19 +8,27 @@ import {
 } from './constants';
 import type { NewsroomPayload } from './types';
 import { normalizeBriefings } from './normalize-briefing';
-import { SEED_NEWSROOM_PAYLOAD } from './seed';
 
 export const NEWSROOM_KV_KEY = 'newsroom:briefings:v1';
+
+const EMPTY_PAYLOAD: NewsroomPayload = {
+  updatedAt: new Date().toISOString(),
+  briefings: [],
+  source: 'unavailable',
+};
 
 /** Cached live RSS ingest — used when KV is empty or stale. */
 const getCachedLiveIngest = unstable_cache(
   async () => ingestNewsroomBriefings(),
-  ['newsroom-live-ingest-v2'],
+  ['newsroom-live-ingest-v3'],
   { revalidate: NEWSROOM_CACHE_SECONDS, tags: ['newsroom'] },
 );
 
 function isLivePayload(payload: NewsroomPayload): boolean {
-  return payload.source === 'google-news-rss' || payload.source === 'kv-cache';
+  return (
+    (payload.source === 'google-news-rss' || payload.source === 'kv-cache') &&
+    payload.briefings.length > 0
+  );
 }
 
 function payloadAgeHours(updatedAt: string): number {
@@ -53,7 +61,7 @@ export async function getNewsroomPayload(): Promise<NewsroomPayload> {
 
   try {
     const live = await getCachedLiveIngest();
-    if (live.briefings.length >= 3 && live.source === 'google-news-rss') {
+    if (live.briefings.length > 0) {
       if (process.env.KV_REST_API_URL) {
         void setNewsroomPayload(live).catch((err) => {
           console.warn('[newsroom] KV backfill after live ingest failed:', err);
@@ -65,13 +73,17 @@ export async function getNewsroomPayload(): Promise<NewsroomPayload> {
     console.warn('[newsroom] Live ingest failed:', error);
   }
 
-  return { ...SEED_NEWSROOM_PAYLOAD, briefings: normalizeBriefings(SEED_NEWSROOM_PAYLOAD.briefings) };
+  return { ...EMPTY_PAYLOAD, updatedAt: new Date().toISOString() };
 }
 
 export async function setNewsroomPayload(payload: NewsroomPayload): Promise<boolean> {
   if (!process.env.KV_REST_API_URL) {
     return false;
   }
-  await kv.set(NEWSROOM_KV_KEY, payload, { ex: NEWSROOM_KV_TTL_SECONDS });
+  if (payload.briefings.length === 0 || payload.source === 'unavailable' || payload.source === 'seed') {
+    console.warn('[newsroom] Skipping KV write — no live briefings');
+    return false;
+  }
+  await kv.set(NEWSROOM_KV_KEY, { ...payload, source: 'google-news-rss' }, { ex: NEWSROOM_KV_TTL_SECONDS });
   return true;
 }

--- a/lib/newsroom/types.ts
+++ b/lib/newsroom/types.ts
@@ -25,5 +25,5 @@ export interface NewsroomBriefing {
 export interface NewsroomPayload {
   updatedAt: string;
   briefings: NewsroomBriefing[];
-  source: 'google-news-rss' | 'seed' | 'kv-cache';
+  source: 'google-news-rss' | 'kv-cache' | 'unavailable' | 'seed';
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -61,7 +61,10 @@ export function middleware(request: NextRequest) {
   }
 
   // Open Portfolio (B2B surface): path-fork before any P.-specific logic runs.
-  // Any O. host other than the canonical apex 307-redirects to www.openportfolio.co.uk.
+  // Any O. host other than the canonical hostname uses a permanent redirect (308)
+  // to www.openportfolio.co.uk so crawlers consolidate duplicates (GSC:
+  // "Duplicate without user-selected canonical" on apex). Temporary 307 here would
+  // override next.config permanent redirects because middleware runs first on Vercel.
   // The canonical host gets an internal rewrite to /open/<path> so the Next.js
   // route group at app/open/ handles the request with O. chrome + metadata.
   if (isOpenHost(host)) {
@@ -69,7 +72,7 @@ export function middleware(request: NextRequest) {
     if (host !== openCanonical) {
       const url = request.nextUrl.clone();
       url.hostname = openCanonical;
-      return NextResponse.redirect(url, 307);
+      return NextResponse.redirect(url, 308);
     }
 
     const pathname = request.nextUrl.pathname;

--- a/tests/unit/newsroom.spec.ts
+++ b/tests/unit/newsroom.spec.ts
@@ -5,6 +5,7 @@ import {
   tagsForCategory,
 } from '../../lib/newsroom/categories';
 import { parseRssFeed } from '../../lib/newsroom/parse-rss';
+import { resolveBriefingHref } from '../../lib/newsroom/resolve-href';
 
 describe('newsroom categories', () => {
   it('classifies FCA/compliance headlines', () => {
@@ -58,5 +59,33 @@ describe('parseRssFeed', () => {
     </item></channel></rss>`;
     const items = parseRssFeed(xml, 'Example');
     expect(items[0].sourceSiteUrl).toBe('https://www.professionaladviser.com');
+  });
+
+  it('extracts direct FCA article links', () => {
+    const xml = `<?xml version="1.0"?><rss><channel><item>
+      <title>FCA press release</title>
+      <link>https://www.fca.org.uk/news/press-releases/example-story</link>
+      <pubDate>Mon, 18 May 2026 10:00:00 GMT</pubDate>
+    </item></channel></rss>`;
+    const items = parseRssFeed(xml, 'FCA');
+    expect(resolveBriefingHref(items[0])).toBe(
+      'https://www.fca.org.uk/news/press-releases/example-story',
+    );
+  });
+});
+
+describe('resolveBriefingHref', () => {
+  it('maps Google News article URLs to title search', () => {
+    const item = {
+      title: 'Revolut wins FCA approval',
+      url: 'https://news.google.com/rss/articles/CBMiabc123?oc=5',
+      source: 'TheBanker',
+      sourceSiteUrl: 'https://www.thebanker.com',
+      publishedAt: new Date().toISOString(),
+      image: null,
+    };
+    const href = resolveBriefingHref(item);
+    expect(href).toContain('news.google.com/search');
+    expect(href).toContain(encodeURIComponent('Revolut wins FCA approval'));
   });
 });


### PR DESCRIPTION
## Problem\nNews Room showed \source: seed\ with static copy linking to FCA homepage, Open architecture, and /for/advisors — not real articles.\n\n## Fix\n- Curated publisher RSS (FCA, Money Marketing, The Fintech Times) with direct article URLs\n- Google News supplement uses title-specific search links (not opaque redirects)\n- Safe RSS date parsing (was throwing Invalid time value)\n- API never returns seed; empty state when ingest fails\n- Cron returns 502 and skips KV if zero briefings\n\n## Verified\n- \
pm run build\ pass\n- Local \/api/newsroom\ returns 6 live items with fca.org.uk/news/... links

Made with [Cursor](https://cursor.com)