### PR TITLE
feat(advisors): SOTA B2B funnel + theme-aware surfaces (Epic 3.4)

### DIFF
--- a/app/for/advisors/AdvisorLandingSections.tsx
+++ b/app/for/advisors/AdvisorLandingSections.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import Link from 'next/link';
+import PocketLandingVisual from '@/app/components/pocket-landing/PocketLandingVisual';
+import { pocketVisual } from '@/lib/pocket-landing-visuals';
+
+const MOAT_CARDS = [
+  {
+    title: 'Stateless Edge Processing',
+    body:
+      'Report generation runs in your browser. Client ledger rows are not warehoused on our servers for PDF inference — reducing third-party data liability.',
+  },
+  {
+    title: 'White-Labeled Client Reports',
+    body:
+      'Upload your firm logo and preview branded portfolio teardowns instantly. High-resolution PDF export with Corporate License.',
+  },
+  {
+    title: 'GDPR-Aligned Architecture',
+    body:
+      'Built for advisors who cannot treat client books as SaaS inventory. Edge-compute by construction, not policy slides alone.',
+  },
+] as const;
+
+export function AdvisorHeroSection() {
+  const heroPlate = { ...pocketVisual('portalStorage'), overlay: 'none' as const, aspectRatio: '21 / 9' };
+
+  return (
+    <section
+      aria-labelledby="advisor-hero-heading"
+      style={{
+        marginBottom: 'clamp(48px, 8vw, 80px)',
+        marginLeft: 'calc(-1 * var(--space-4))',
+        marginRight: 'calc(-1 * var(--space-4))',
+      }}
+    >
+      <div className="advisor-hero-shell" style={{ position: 'relative', overflow: 'hidden' }}>
+        <div
+          className="advisor-hero-plate"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            pointerEvents: 'none',
+          }}
+        >
+          <PocketLandingVisual visual={heroPlate} priority variant="section" />
+        </div>
+        <div aria-hidden className="advisor-hero-overlay" style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }} />
+        <div
+          style={{
+            position: 'relative',
+            zIndex: 2,
+            maxWidth: '860px',
+            margin: '0 auto',
+            padding: 'clamp(48px, 8vw, 88px) clamp(20px, 4vw, 32px) clamp(40px, 6vw, 64px)',
+            textAlign: 'center',
+          }}
+        >
+          <p className="advisor-eyebrow">For IFAs &amp; Wealth Operators</p>
+          <h1
+            id="advisor-hero-heading"
+            style={{
+              fontSize: 'clamp(1.75rem, 4vw, 2.75rem)',
+              fontWeight: 800,
+              lineHeight: 1.08,
+              letterSpacing: '-0.03em',
+              color: 'var(--text)',
+              margin: '0 0 20px',
+            }}
+          >
+            Secure Client Intelligence. Zero Data Liability.
+          </h1>
+          <p
+            style={{
+              fontSize: 'clamp(1.05rem, 2vw, 1.25rem)',
+              lineHeight: 1.65,
+              color: 'var(--text-secondary)',
+              margin: '0 auto 24px',
+              maxWidth: '720px',
+            }}
+          >
+            Equip your firm with institutional-grade portfolio teardowns. Powered by our stateless edge-engine,
+            you can generate white-labeled insights without ever warehousing your clients&apos; raw ledgers on
+            third-party servers.
+          </p>
+          <div className="advisor-trust-band">
+            GDPR-Compliant. Stateless Processing. Your Firm&apos;s Branding.
+          </div>
+          <div style={{ marginTop: '28px' }}>
+            <a
+              href="#advisor-iad"
+              className="brand-button brand-button-primary"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '14px 28px',
+                fontSize: '15px',
+                fontWeight: 800,
+                textDecoration: 'none',
+              }}
+            >
+              Test the Edge Engine
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function AdvisorMoatSection() {
+  return (
+    <section
+      aria-labelledby="advisor-moat-heading"
+      style={{
+        marginBottom: 'clamp(48px, 8vw, 72px)',
+      }}
+    >
+      <h2
+        id="advisor-moat-heading"
+        style={{
+          fontSize: 'clamp(1.25rem, 2.5vw, 1.5rem)',
+          fontWeight: 800,
+          letterSpacing: '-0.02em',
+          textAlign: 'center',
+          marginBottom: '12px',
+          color: 'var(--text)',
+        }}
+      >
+        Why advisors trust the architecture
+      </h2>
+      <p
+        style={{
+          textAlign: 'center',
+          color: 'var(--text-secondary)',
+          maxWidth: '640px',
+          margin: '0 auto 32px',
+          lineHeight: 1.6,
+          fontSize: 'var(--font-size-base)',
+        }}
+      >
+        Before you upload a logo or generate a report, understand the boundary: client books stay on the edge;
+        our servers do not warehouse raw ledger rows for this workflow.
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+          gap: 'var(--space-5)',
+        }}
+      >
+        {MOAT_CARDS.map((card) => (
+          <div key={card.title} className="brand-card" style={{ padding: 'var(--space-5)' }}>
+            <h3
+              style={{
+                fontWeight: 'var(--font-semibold)',
+                color: 'var(--text)',
+                marginBottom: 'var(--space-2)',
+                fontSize: 'var(--font-size-base)',
+              }}
+            >
+              {card.title}
+            </h3>
+            <p
+              style={{
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--text-secondary)',
+                lineHeight: 'var(--line-relaxed)',
+                margin: 0,
+              }}
+            >
+              {card.body}
+            </p>
+          </div>
+        ))}
+      </div>
+      <p style={{ textAlign: 'center', marginTop: '24px', fontSize: 'var(--font-size-sm)' }}>
+        <Link href="/architecture" className="advisor-architecture-link">
+          Read the technical architecture →
+        </Link>
+      </p>
+    </section>
+  );
+}
+
+export function AdvisorTerminalSectionHeader() {
+  return (
+    <div
+      id="advisor-iad"
+      style={{
+        scrollMarginTop: '96px',
+        marginBottom: 'var(--space-6)',
+        textAlign: 'center',
+      }}
+    >
+      <p className="advisor-eyebrow" style={{ marginBottom: '10px' }}>
+        Interactive Architecture Demonstration
+      </p>
+      <h2
+        style={{
+          fontSize: 'clamp(1.25rem, 2.5vw, 1.75rem)',
+          fontWeight: 800,
+          color: 'var(--text)',
+          marginBottom: '12px',
+          letterSpacing: '-0.02em',
+        }}
+      >
+        Interactive Terminal: Test the Edge-Generation Engine
+      </h2>
+      <p
+        style={{
+          maxWidth: '680px',
+          margin: '0 auto',
+          color: 'var(--text-secondary)',
+          lineHeight: 1.6,
+          fontSize: 'var(--font-size-base)',
+        }}
+      >
+        Logo upload and report preview run in your browser. Sample data is shown until you import trades — no raw
+        client ledger is sent to our servers for this demo.
+      </p>
+    </div>
+  );
+}

--- a/app/for/advisors/AdvisorTool.tsx
+++ b/app/for/advisors/AdvisorTool.tsx
@@ -581,7 +581,7 @@ export default function AdvisorTool() {
 
   return (
     <>
-      <div className="brand-card" style={{ padding: 'var(--space-6)' }}>
+      <div className="advisor-glass-panel">
       {/* Client Name Editor */}
       <div style={{ marginBottom: 'var(--space-6)' }}>
         <label style={{
@@ -704,29 +704,25 @@ export default function AdvisorTool() {
           fontSize: 'var(--font-size-sm)',
           color: 'var(--text-secondary)'
         }}>
-          Your logo will replace Pocket Portfolio branding in the report preview
+          Logo files stay in your browser for preview and PDF generation — not uploaded to our servers for this
+          workflow.
         </p>
       </div>
 
       {/* PDF Preview */}
       <div style={{ marginBottom: 'var(--space-8)' }}>
-        <h2 style={{
-          fontSize: 'var(--font-size-xl)',
+        <h3 style={{
+          fontSize: 'var(--font-size-lg)',
           fontWeight: 'var(--font-semibold)',
           color: 'var(--text)',
           marginBottom: 'var(--space-4)'
         }}>
-          Report Preview
-        </h2>
-        <div 
+          Live Report Preview
+        </h3>
+        <div
           ref={reportPreviewRef}
-          style={{
-            border: '2px solid var(--border)',
-            borderRadius: 'var(--radius-md)',
-            padding: 'var(--space-6)',
-            background: 'var(--surface-elevated)',
-            position: 'relative'
-          }}
+          className="advisor-download-preview"
+          style={{ position: 'relative' }}
         >
           {/* Report Header */}
           <div style={{
@@ -934,25 +930,17 @@ export default function AdvisorTool() {
           style={{
             padding: 'var(--space-4) var(--space-8)',
             fontSize: 'var(--font-size-lg)',
-            opacity: hasCorporateLicense ? 1 : 0.7
+            borderColor: hasCorporateLicense ? undefined : 'var(--border-warm)',
           }}
         >
           Download High-Res PDF
         </button>
         {!hasCorporateLicense && (
-          <p style={{
-            marginTop: 'var(--space-3)',
-            fontSize: 'var(--font-size-sm)',
-            color: 'var(--text-secondary)'
-          }}>
+          <p className="advisor-download-gate">
             Requires Corporate License ($100/mo) •{' '}
-            <Link 
+            <Link
               href="/sponsor?utm_source=advisor_tool&utm_medium=download_gate&utm_campaign=corporate"
               className="brand-link"
-              style={{
-                color: 'var(--signal)',
-                fontWeight: 'var(--font-semibold)'
-              }}
             >
               Get License →
             </Link>

--- a/app/for/advisors/advisors.css
+++ b/app/for/advisors/advisors.css
@@ -1,0 +1,100 @@
+/**
+ * /for/advisors — theme-aware SOTA surfaces (light + dark via design tokens).
+ */
+
+.advisor-hero-shell {
+  background: var(--bg);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent-warm) 18%, var(--border));
+}
+
+.advisor-hero-plate {
+  opacity: 0.55;
+}
+
+[data-theme='light'] .advisor-hero-plate {
+  opacity: 0.22;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme='dark']) .advisor-hero-plate {
+    opacity: 0.22;
+  }
+}
+
+.advisor-hero-overlay {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--bg) 25%, transparent) 0%,
+    color-mix(in srgb, var(--bg) 82%, transparent) 55%,
+    var(--bg) 100%
+  );
+}
+
+.advisor-trust-band {
+  display: inline-block;
+  max-width: 720px;
+  padding: 14px clamp(12px, 3vw, 18px);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--accent-warm) 35%, var(--border));
+  background: color-mix(in srgb, var(--accent-warm) 10%, var(--surface));
+  font-family: var(--font-mono);
+  font-size: clamp(0.8125rem, 1.5vw, 0.9375rem);
+  line-height: 1.55;
+  letter-spacing: 0.03em;
+  color: var(--accent-warm);
+}
+
+.advisor-glass-panel {
+  background: color-mix(in srgb, var(--surface-elevated) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-warm) 28%, var(--border));
+  border-radius: 16px;
+  padding: var(--space-6);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-lg);
+}
+
+.advisor-moat-card {
+  padding: var(--space-5);
+  background: var(--surface-elevated);
+  border: 1px solid color-mix(in srgb, var(--accent-warm) 22%, var(--border));
+  border-radius: var(--radius-md);
+}
+
+.advisor-eyebrow {
+  margin: 0 0 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-warm);
+}
+
+.advisor-architecture-link {
+  color: var(--accent-warm);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.advisor-architecture-link:hover {
+  text-decoration: underline;
+}
+
+.advisor-download-gate {
+  margin-top: var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.advisor-download-gate a {
+  color: var(--accent-warm);
+  font-weight: var(--font-semibold);
+}
+
+.advisor-download-preview {
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  background: var(--surface-elevated);
+}

--- a/app/for/advisors/page.tsx
+++ b/app/for/advisors/page.tsx
@@ -1,20 +1,34 @@
 import { Metadata } from 'next';
 import AdvisorTool from './AdvisorTool';
+import {
+  AdvisorHeroSection,
+  AdvisorMoatSection,
+  AdvisorTerminalSectionHeader,
+} from './AdvisorLandingSections';
 
 export const metadata: Metadata = {
-  title: 'White Label Portfolio Report Generator for Financial Advisors | Pocket Portfolio',
-  description: 'Generate professional client portfolio reports with your firm logo. Preview free, download high-res PDFs with Corporate License ($100/mo).',
-  keywords: ['white label portfolio report', 'financial advisor report generator', 'client portfolio pdf', 'advisor reporting tool'],
+  title: 'Secure Client Intelligence for Financial Advisors | Pocket Portfolio',
+  description:
+    'Generate white-labeled portfolio reports with stateless edge processing. Preview free; Corporate License for high-res PDFs. GDPR-aligned architecture for IFAs.',
+  keywords: [
+    'financial advisor portfolio report',
+    'white label portfolio report',
+    'GDPR portfolio reporting',
+    'IFA client reporting tool',
+    'stateless portfolio PDF',
+  ],
   openGraph: {
-    title: 'White Label Portfolio Report Generator for Financial Advisors',
-    description: 'Generate professional client portfolio reports with your firm logo.',
+    title: 'Secure Client Intelligence. Zero Data Liability.',
+    description:
+      'White-labeled portfolio teardowns powered by stateless edge processing — without warehousing client ledgers on third-party servers.',
     type: 'website',
     url: 'https://www.pocketportfolio.app/for/advisors',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'White Label Portfolio Report Generator for Financial Advisors',
-    description: 'Generate professional client portfolio reports with your firm logo.',
+    title: 'Secure Client Intelligence for Financial Advisors',
+    description:
+      'Stateless edge-engine for white-labeled client portfolio reports. Preview free with Corporate License PDF export.',
   },
   alternates: {
     canonical: 'https://www.pocketportfolio.app/for/advisors',
@@ -22,25 +36,20 @@ export const metadata: Metadata = {
 };
 
 export default function AdvisorsPage() {
-  // SoftwareApplication schema for SEO
   const softwareAppSchema = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
-    name: 'White Label Portfolio Report Generator',
+    name: 'Pocket Portfolio Advisor Report Generator',
     applicationCategory: 'FinanceApplication',
     operatingSystem: 'Web Browser',
     offers: {
       '@type': 'Offer',
       price: '100',
-      priceCurrency: 'GBP'
+      priceCurrency: 'USD',
     },
-    description: 'Professional portfolio report generator for financial advisors. White label with your firm logo.',
+    description:
+      'White-labeled portfolio report generator for financial advisors with stateless edge processing and browser-local PDF preview.',
     url: 'https://www.pocketportfolio.app/for/advisors',
-    aggregateRating: {
-      '@type': 'AggregateRating',
-      ratingValue: '4.8',
-      ratingCount: '50'
-    }
   };
 
   return (
@@ -49,183 +58,62 @@ export default function AdvisorsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareAppSchema) }}
       />
-      {/* Header */}
-      <div style={{ 
-        textAlign: 'center', 
-        marginBottom: 'var(--space-8)'
-      }}>
-            <h1 style={{
+
+      <AdvisorHeroSection />
+      <AdvisorMoatSection />
+      <AdvisorTerminalSectionHeader />
+      <AdvisorTool />
+
+      {/* Conversion Zone */}
+      <div
+        className="brand-card advisor-glass-panel"
+        style={{
+          marginTop: 'var(--space-12)',
+          textAlign: 'center',
+        }}
+      >
+        <h2
+          style={{
+            fontSize: 'var(--font-size-2xl)',
+            fontWeight: 'var(--font-bold)',
+            color: 'var(--text)',
+            marginBottom: 'var(--space-4)',
+          }}
+        >
+          Corporate License
+        </h2>
+        <p
+          style={{
+            color: 'var(--text-secondary)',
+            maxWidth: '560px',
+            margin: '0 auto var(--space-6)',
+            lineHeight: 'var(--line-relaxed)',
+          }}
+        >
+          Unlimited high-resolution PDF downloads, custom firm branding, and priority support — built for practices
+          that cannot warehouse client books on third-party SaaS.
+        </p>
+        <div style={{ maxWidth: '400px', margin: '0 auto' }}>
+          <div
+            style={{
               fontSize: 'var(--font-size-3xl)',
               fontWeight: 'var(--font-bold)',
               color: 'var(--text)',
-              marginBottom: 'var(--space-4)',
-              lineHeight: 'var(--line-tight)',
-              textShadow: '0 1px 2px rgba(0, 0, 0, 0.1)'
-            }}>
-              White Label Portfolio Reports for Financial Advisors
-            </h1>
-            <p style={{
-              fontSize: 'var(--font-size-lg)',
-              color: 'var(--text-secondary)',
-              lineHeight: 'var(--line-relaxed)',
-              maxWidth: '700px',
-              margin: '0 auto'
-            }}>
-              Generate professional client portfolio reports with your firm branding. Preview free, download high-res PDFs with Corporate License.
-            </p>
+              marginBottom: 'var(--space-2)',
+            }}
+          >
+            $100
+            <span style={{ fontSize: 'var(--font-size-lg)', color: 'var(--text-secondary)' }}>/mo</span>
           </div>
-
-          {/* Tool Component */}
-          <AdvisorTool />
-
-          {/* Features */}
-          <div style={{
-            marginTop: 'var(--space-12)',
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-            gap: 'var(--space-6)'
-          }}>
-            <div className="brand-card" style={{ padding: 'var(--space-5)' }}>
-              <div style={{
-                width: '48px',
-                height: '48px',
-                background: 'var(--surface-elevated)',
-                borderRadius: 'var(--radius-full)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginBottom: 'var(--space-4)',
-                border: '2px solid var(--border-warm)'
-              }}>
-                <svg style={{ width: '24px', height: '24px', color: 'var(--signal)' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-              </div>
-              <h3 style={{
-                fontWeight: 'var(--font-semibold)',
-                color: 'var(--text)',
-                marginBottom: 'var(--space-2)',
-                fontSize: 'var(--font-size-base)'
-              }}>
-                Custom Branding
-              </h3>
-              <p style={{
-                fontSize: 'var(--font-size-sm)',
-                color: 'var(--text-secondary)',
-                lineHeight: 'var(--line-relaxed)'
-              }}>
-                Upload your firm logo and replace Pocket Portfolio branding instantly. Preview updates in real-time.
-              </p>
-            </div>
-            <div className="brand-card" style={{ padding: 'var(--space-5)' }}>
-              <div style={{
-                width: '48px',
-                height: '48px',
-                background: 'var(--surface-elevated)',
-                borderRadius: 'var(--radius-full)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginBottom: 'var(--space-4)',
-                border: '2px solid var(--border-warm)'
-              }}>
-                <svg style={{ width: '24px', height: '24px', color: 'var(--signal)' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-              </div>
-              <h3 style={{
-                fontWeight: 'var(--font-semibold)',
-                color: 'var(--text)',
-                marginBottom: 'var(--space-2)',
-                fontSize: 'var(--font-size-base)'
-              }}>
-                Professional PDFs
-              </h3>
-              <p style={{
-                fontSize: 'var(--font-size-sm)',
-                color: 'var(--text-secondary)',
-                lineHeight: 'var(--line-relaxed)'
-              }}>
-                Generate high-resolution PDF reports perfect for client presentations. No watermarks with Corporate License.
-              </p>
-            </div>
-            <div className="brand-card" style={{ padding: 'var(--space-5)' }}>
-              <div style={{
-                width: '48px',
-                height: '48px',
-                background: 'var(--surface-elevated)',
-                borderRadius: 'var(--radius-full)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginBottom: 'var(--space-4)',
-                border: '2px solid var(--border-warm)'
-              }}>
-                <svg style={{ width: '24px', height: '24px', color: 'var(--signal)' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-                </svg>
-              </div>
-              <h3 style={{
-                fontWeight: 'var(--font-semibold)',
-                color: 'var(--text)',
-                marginBottom: 'var(--space-2)',
-                fontSize: 'var(--font-size-base)'
-              }}>
-                Privacy-First
-              </h3>
-              <p style={{
-                fontSize: 'var(--font-size-sm)',
-                color: 'var(--text-secondary)',
-                lineHeight: 'var(--line-relaxed)'
-              }}>
-                All processing happens locally in your browser. Client data never leaves your device.
-              </p>
-            </div>
-          </div>
-
-          {/* Pricing */}
-          <div className="brand-card" style={{
-            marginTop: 'var(--space-12)',
-            padding: 'var(--space-6)',
-            textAlign: 'center'
-          }}>
-            <h2 style={{
-              fontSize: 'var(--font-size-2xl)',
-              fontWeight: 'var(--font-bold)',
-              color: 'var(--text)',
-              marginBottom: 'var(--space-6)'
-            }}>
-              Corporate License
-            </h2>
-            <div style={{ maxWidth: '400px', margin: '0 auto' }}>
-              <div style={{
-                fontSize: 'var(--font-size-3xl)',
-                fontWeight: 'var(--font-bold)',
-                color: 'var(--text)',
-                marginBottom: 'var(--space-2)'
-              }}>
-                $100<span style={{
-                  fontSize: 'var(--font-size-lg)',
-                  color: 'var(--text-secondary)'
-                }}>/mo</span>
-              </div>
-              <p style={{
-                color: 'var(--text-secondary)',
-                marginBottom: 'var(--space-6)',
-                lineHeight: 'var(--line-relaxed)'
-              }}>
-                Includes unlimited high-res PDF downloads, custom branding, and priority support.
-              </p>
-              <a
-                href="/sponsor?utm_source=advisor_tool&utm_medium=cta&utm_campaign=corporate_license"
-                className="brand-button brand-button-primary"
-                style={{ display: 'inline-block' }}
-              >
-                Get Corporate License
-              </a>
-            </div>
-          </div>
-
+          <a
+            href="/sponsor?utm_source=advisor_tool&utm_medium=cta&utm_campaign=corporate_license"
+            className="brand-button brand-button-primary"
+            style={{ display: 'inline-block' }}
+          >
+            Get Corporate License
+          </a>
+        </div>
+      </div>
     </>
   );
 }

--- a/app/for/layout.tsx
+++ b/app/for/layout.tsx
@@ -1,5 +1,6 @@
 import ProductionNavbar from '@/app/components/marketing/ProductionNavbar';
 import SEOPageTracker from '@/app/components/SEOPageTracker';
+import './advisors/advisors.css';
 
 export default function ForLayout({
   children,
@@ -13,6 +14,7 @@ export default function ForLayout({
         display: 'flex',
         flexDirection: 'column',
         background: 'var(--bg)',
+        color: 'var(--text)',
         fontFamily: 'system-ui, -apple-system, sans-serif',
         width: '100%',
         maxWidth: '100vw',


### PR DESCRIPTION
## Summary
- Restructures /for/advisors from cold-drop form into Hero, Moat, IAD Terminal, and Conversion zones with calibrated copy per claims-vs-codebase-calibration.md
- Adds theme-aware CSS (light/dark) via design tokens — removes hardcoded obsidian
- Fixes download CTA contrast and logo-upload calibration copy

## Test plan
- [ ] /for/advisors returns 200 (not 404)
- [ ] Toggle light/dark — full page follows theme (nav, hero, moat, terminal, pricing, footer)
- [ ] Hero copy: Secure Client Intelligence headline + trust band
- [ ] Terminal IAD renders below moat with glass panel
- [ ] Download gate readable in both themes

Made with [Cursor](https://cursor.com)