### PR TITLE
feat(sponsor): persona tabs — CMD-UI-SPONSOR-2026-06-10 [STAGING QA REQUIRED]

### DIFF
--- a/app/components/sponsor/SponsorDeck.tsx
+++ b/app/components/sponsor/SponsorDeck.tsx
@@ -1,349 +1,47 @@
 'use client';
 
-import { useState } from 'react';
-import { motion } from 'framer-motion';
+import { useCallback, useState } from 'react';
+import Link from 'next/link';
 
-interface TierCardProps {
-  id: string;
-  title: string;
-  price: string;
-  priceSubtext?: string;
-  description: string;
-  icon: string;
-  iconAlt: string;
-  color: string;
-  isPopular?: boolean;
-  isExpanded: boolean;
-  onExpand: () => void;
-  onCheckout: (interval?: 'monthly' | 'annual') => void;
-  loading?: boolean;
-  previewTheme?: 'founder' | 'corporate' | null;
-  onPreviewTheme?: (theme: 'founder' | 'corporate' | null) => void;
-  children?: React.ReactNode;
-  isFoundersClub?: boolean;
-  foundersClubScarcity?: { count: number; batch: number; label: string; progress: number; remaining: number; max: number } | null;
-  founderCheckoutIntervals?: { label: string; interval: 'monthly' | 'annual' }[];
-  priceId?: string | { monthly: string; annual: string };
+export type SponsorPersonaTab = 'investors' | 'developers' | 'institutions';
+
+const PERSONA_TABS: { id: SponsorPersonaTab; label: string }[] = [
+  { id: 'investors', label: 'For investors' },
+  { id: 'developers', label: 'For developers' },
+  { id: 'institutions', label: 'For institutions' },
+];
+
+/** Map legacy `?tier=` deep links to persona panes (Stripe objects unchanged). */
+export function resolveSponsorPersonaTab(tier: string | null): SponsorPersonaTab | null {
+  if (!tier) return null;
+  switch (tier) {
+    case 'founder':
+      return 'investors';
+    case 'code-supporter':
+    case 'developer-utility':
+      return 'developers';
+    case 'corporate':
+      return 'institutions';
+    default:
+      return null;
+  }
 }
 
-function TierCard({
-  id,
-  title,
-  price,
-  priceSubtext,
-  description,
-  icon,
-  iconAlt,
-  color,
-  isPopular = false,
-  isExpanded,
-  onExpand,
-  onCheckout,
-  loading = false,
-  previewTheme,
-  onPreviewTheme,
-  children,
-  isFoundersClub = false,
-  foundersClubScarcity,
-  founderCheckoutIntervals,
-  priceId: tierPriceId
-}: TierCardProps) {
-  return (
-    <motion.div
-      layout
-      onHoverStart={onExpand}
-      onClick={onExpand}
-      style={{
-        flex: isExpanded ? 3 : 1,
-        minWidth: isExpanded ? '400px' : '120px',
-        height: '600px',
-        background: isExpanded 
-          ? (isFoundersClub 
-              ? 'linear-gradient(135deg, var(--surface) 0%, rgba(245, 158, 11, 0.05) 100%)'
-              : 'var(--surface)')
-          : 'linear-gradient(135deg, var(--surface) 0%, var(--surface-elevated) 100%)',
-        border: isExpanded 
-          ? (isFoundersClub ? '3px solid #f59e0b' : `2px solid ${color}`)
-          : '2px solid var(--border)',
-        borderRadius: '12px',
-        padding: isExpanded ? 'clamp(20px, 4vw, 32px)' : '16px',
-        display: 'flex',
-        flexDirection: 'column',
-        cursor: 'pointer',
-        transition: 'all 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
-        boxShadow: isExpanded 
-          ? (isFoundersClub 
-              ? '0 8px 24px rgba(245, 158, 11, 0.4)'
-              : '0 8px 24px rgba(0, 0, 0, 0.15)')
-          : '0 2px 8px rgba(0, 0, 0, 0.1)',
-        opacity: isExpanded ? 1 : 0.7,
-        filter: isExpanded ? 'grayscale(0)' : 'grayscale(0.3)',
-        overflow: 'hidden',
-        position: 'relative'
-      }}
-      whileHover={!isExpanded ? {
-        flex: 1.2,
-        opacity: 0.9,
-        filter: 'grayscale(0.1)'
-      } : {}}
-    >
-      {/* Background overlay for compressed state */}
-      {!isExpanded && (
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            background: `linear-gradient(135deg, ${color}15 0%, transparent 100%)`,
-            pointerEvents: 'none'
-          }}
-        />
-      )}
-
-      {isExpanded ? (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.1 }}
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100%',
-            overflow: 'hidden',
-            position: 'relative'
-          }}
-        >
-          {/* Popular Badge - Fixed position */}
-          {isPopular && (
-            <div style={{
-              position: 'absolute',
-              top: '16px',
-              right: '16px',
-              background: 'var(--accent-warm)',
-              color: 'white',
-              padding: '4px 12px',
-              borderRadius: '12px',
-              fontSize: '12px',
-              fontWeight: '600',
-              zIndex: 10
-            }}>
-              Popular
-            </div>
-          )}
-
-          {/* Scrollable content area */}
-          <div 
-            style={{
-              flex: '1 1 auto',
-              overflowY: 'auto',
-              overflowX: 'hidden',
-              paddingRight: '8px',
-              minHeight: 0
-            }}
-            className="sponsor-deck-scrollbar"
-          >
-            {/* Icon */}
-            <div style={{
-              width: '80px',
-              height: '80px',
-              margin: '0 auto 20px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}>
-              <img 
-                src={icon} 
-                alt={iconAlt}
-                style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-              />
-            </div>
-
-            {/* Title */}
-            <h3 style={{
-              fontSize: 'clamp(20px, 3vw, 24px)',
-              fontWeight: 'bold',
-              marginBottom: '8px',
-              color: 'var(--text)',
-              textAlign: 'center'
-            }}>
-              {title}
-            </h3>
-
-            {/* Price */}
-            <div style={{
-              fontSize: 'clamp(28px, 5vw, 36px)',
-              fontWeight: 'bold',
-              color: color,
-              marginBottom: '8px',
-              textAlign: 'center'
-            }}>
-              {price}
-              {priceSubtext && (
-                <span style={{
-                  fontSize: 'clamp(14px, 2.5vw, 18px)',
-                  color: 'var(--text-secondary)',
-                  fontWeight: 'normal'
-                }}>
-                  {priceSubtext}
-                </span>
-              )}
-            </div>
-
-            {/* Description */}
-            <p style={{
-              color: 'var(--text-secondary)',
-              marginBottom: '16px',
-              lineHeight: '1.6',
-              textAlign: 'center',
-              fontSize: '14px'
-            }}>
-              {description}
-            </p>
-
-            {/* Tier-specific content - ALL FEATURES HERE */}
-            {children}
-          </div>
-
-          {/* CTA Button - Fixed at bottom */}
-          <div style={{ 
-            flexShrink: 0,
-            display: 'flex', 
-            flexDirection: 'column', 
-            gap: '12px',
-            paddingTop: '16px',
-            borderTop: '1px solid var(--border)',
-            background: isFoundersClub 
-              ? 'linear-gradient(135deg, var(--surface) 0%, rgba(245, 158, 11, 0.05) 100%)'
-              : 'var(--surface)'
-          }}>
-            {founderCheckoutIntervals && founderCheckoutIntervals.length > 0 ? (
-              founderCheckoutIntervals.map(({ label, interval }) => (
-                <button
-                  key={interval}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onCheckout(interval);
-                  }}
-                  disabled={loading}
-                  style={{
-                    padding: '12px 24px',
-                    background: loading ? 'var(--muted)' : interval === 'annual' ? color : 'transparent',
-                    color: loading ? 'var(--text-secondary)' : interval === 'annual' ? 'white' : color,
-                    border: `2px solid ${color}`,
-                    borderRadius: '8px',
-                    fontSize: '14px',
-                    fontWeight: '600',
-                    cursor: loading ? 'not-allowed' : 'pointer',
-                    transition: 'all 0.2s ease',
-                    opacity: loading ? 0.6 : 1,
-                    width: '100%'
-                  }}
-                >
-                  {loading ? 'Processing...' : label}
-                </button>
-              ))
-            ) : (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCheckout();
-                }}
-                disabled={loading}
-                style={{
-                  padding: '12px 24px',
-                  background: loading ? 'var(--muted)' : color,
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '8px',
-                  fontSize: '16px',
-                  fontWeight: '600',
-                  cursor: loading ? 'not-allowed' : 'pointer',
-                  transition: 'all 0.2s ease',
-                  opacity: loading ? 0.6 : 1,
-                  width: '100%'
-                }}
-              >
-                {loading ? 'Processing...' : (isFoundersClub ? 'Join UK Founder\'s Club' : 'Subscribe (Annual)')}
-              </button>
-            )}
-            
-            {/* Preview Theme Button for Corporate/Founder */}
-            {(id === 'corporate' || id === 'founder') && onPreviewTheme && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const theme = id === 'founder' ? 'founder' : 'corporate';
-                  onPreviewTheme(previewTheme === theme ? null : theme);
-                }}
-                style={{
-                  padding: '12px 20px',
-                  background: previewTheme === (id === 'founder' ? 'founder' : 'corporate') 
-                    ? 'var(--muted)' 
-                    : 'transparent',
-                  color: color,
-                  border: `2px solid ${color}`,
-                  borderRadius: '8px',
-                  fontSize: '14px',
-                  fontWeight: '600',
-                  cursor: 'pointer',
-                  transition: 'all 0.2s ease',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '6px',
-                  textTransform: id === 'founder' ? 'uppercase' : 'none',
-                  letterSpacing: id === 'founder' ? '0.5px' : 'normal',
-                  width: '100%'
-                }}
-              >
-                {previewTheme === (id === 'founder' ? 'founder' : 'corporate') 
-                  ? '✕ Close Preview' 
-                  : (id === 'founder' ? '✨ Preview Gold Theme' : '👁️ Preview Terminal Theme')}
-              </button>
-            )}
-          </div>
-        </motion.div>
-      ) : (
-        <div style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          gap: '16px'
-        }}>
-          {/* Compressed: Vertical rotated title */}
-          <motion.div
-            style={{
-              transform: 'rotate(-90deg)',
-              whiteSpace: 'nowrap',
-              fontSize: '18px',
-              fontWeight: 'bold',
-              color: 'var(--text-secondary)',
-              letterSpacing: '2px',
-              textTransform: 'uppercase'
-            }}
-          >
-            {title}
-          </motion.div>
-          
-          {/* Compressed: Price hint */}
-          <div style={{
-            fontSize: '12px',
-            color: 'var(--muted)',
-            opacity: 0.6
-          }}>
-            View Plan
-          </div>
-        </div>
-      )}
-    </motion.div>
-  );
-}
-
-export type FoundersClubScarcity = { count: number; batch: number; label: string; progress: number; remaining: number; max: number } | null;
+export type FoundersClubScarcity = {
+  count: number;
+  batch: number;
+  label: string;
+  progress: number;
+  remaining: number;
+  max: number;
+} | null;
 
 interface SponsorDeckProps {
-  onCheckout: (priceId: string | { monthly: string; annual: string }, tierName: string, chosenInterval?: 'monthly' | 'annual') => void;
+  onCheckout: (
+    priceId: string | { monthly: string; annual: string },
+    tierName: string,
+    chosenInterval?: 'monthly' | 'annual',
+  ) => void;
   loading: string | null;
   previewTheme: 'founder' | 'corporate' | null;
   onPreviewTheme: (theme: 'founder' | 'corporate' | null) => void;
@@ -356,6 +54,203 @@ interface SponsorDeckProps {
   foundersClubScarcity?: FoundersClubScarcity;
   /** Sponsor A/B: A = Join Founders + monthly default; B = AI/Risk headline + annual default */
   abVariant?: 'A' | 'B';
+  /** Initial persona pane — defaults to investors per CMD-UI-SPONSOR-2026-06-10 */
+  initialTab?: SponsorPersonaTab;
+}
+
+function isPriceLoading(
+  loading: string | null,
+  priceId: string | { monthly: string; annual: string },
+): boolean {
+  if (!loading) return false;
+  if (typeof priceId === 'string') return loading === priceId;
+  return loading === priceId.monthly || loading === priceId.annual;
+}
+
+function FeatureBlock({ title, children }: { title: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        marginBottom: '12px',
+        padding: '12px',
+        background: 'var(--surface-elevated)',
+        borderRadius: '8px',
+        border: '1px solid var(--border-subtle, var(--border))',
+      }}
+    >
+      <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function FeatureBulletList({ items }: { items: string[] }) {
+  return (
+    <ul
+      style={{
+        fontSize: '13px',
+        color: 'var(--text-secondary)',
+        marginLeft: '20px',
+        marginTop: '8px',
+        lineHeight: 1.8,
+        padding: 0,
+        listStyle: 'none',
+      }}
+    >
+      {items.map((item) => (
+        <li key={item} style={{ marginBottom: '4px' }}>
+          • {item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function SavingsBanner({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        marginBottom: '12px',
+        fontSize: '13px',
+        color: 'var(--accent-warm)',
+        fontWeight: '600',
+        background: 'rgba(245, 158, 11, 0.1)',
+        padding: '8px',
+        borderRadius: '6px',
+        textAlign: 'center',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function UkFounderBadge() {
+  return (
+    <svg
+      width="16"
+      height="12"
+      viewBox="0 0 16 12"
+      style={{ marginLeft: '6px', opacity: 0.7, verticalAlign: 'middle' }}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect width="16" height="12" fill="#012169" />
+      <path d="M0 0 L16 12 M16 0 L0 12" stroke="#FFFFFF" strokeWidth="2" />
+      <path d="M8 0 L8 12 M0 6 L16 6" stroke="#FFFFFF" strokeWidth="2.5" />
+      <path d="M0 0 L16 12 M16 0 L0 12" stroke="#C8102E" strokeWidth="1.2" />
+      <path d="M8 0 L8 12 M0 6 L16 6" stroke="#C8102E" strokeWidth="1.5" />
+      <path d="M0 0 L5.33 0 L0 3.56 Z" fill="#FFFFFF" />
+      <path d="M16 0 L10.67 0 L16 3.56 Z" fill="#FFFFFF" />
+      <path d="M0 12 L5.33 12 L0 8.44 Z" fill="#FFFFFF" />
+      <path d="M16 12 L10.67 12 L16 8.44 Z" fill="#FFFFFF" />
+    </svg>
+  );
+}
+
+function SubscribeButton({
+  onClick,
+  loading,
+  disabled,
+  label = 'Subscribe (Annual)',
+  variant = 'primary',
+}: {
+  onClick: () => void;
+  loading: boolean;
+  disabled: boolean;
+  label?: string;
+  variant?: 'primary' | 'outline';
+}) {
+  const isPrimary = variant === 'primary';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: '12px 24px',
+        background: loading ? 'var(--muted)' : isPrimary ? 'var(--accent-warm)' : 'transparent',
+        color: loading ? 'var(--text-secondary)' : isPrimary ? 'white' : 'var(--accent-warm)',
+        border: isPrimary ? 'none' : '2px solid var(--accent-warm)',
+        borderRadius: '8px',
+        fontSize: '16px',
+        fontWeight: '600',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        transition: 'all 0.15s ease',
+        opacity: disabled && !loading ? 0.6 : 1,
+        width: '100%',
+      }}
+    >
+      {loading ? 'Processing...' : label}
+    </button>
+  );
+}
+
+function BillingIntervalButtons({
+  priceIds,
+  tierName,
+  onCheckout,
+  loading,
+  checkoutBusy,
+  monthlyLabel,
+  annualLabel,
+}: {
+  priceIds: { monthly: string; annual: string };
+  tierName: string;
+  onCheckout: SponsorDeckProps['onCheckout'];
+  loading: string | null;
+  checkoutBusy: boolean;
+  monthlyLabel: string;
+  annualLabel: string;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '4px' }}>
+      <SubscribeButton
+        onClick={() => onCheckout(priceIds, tierName, 'monthly')}
+        loading={loading === priceIds.monthly}
+        disabled={checkoutBusy}
+        label={monthlyLabel}
+        variant="outline"
+      />
+      <SubscribeButton
+        onClick={() => onCheckout(priceIds, tierName, 'annual')}
+        loading={loading === priceIds.annual}
+        disabled={checkoutBusy}
+        label={annualLabel}
+        variant="primary"
+      />
+    </div>
+  );
+}
+
+function DualPriceHeadline({
+  monthly,
+  annual,
+}: {
+  monthly: React.ReactNode;
+  annual: React.ReactNode;
+}) {
+  return (
+    <div style={{ marginBottom: '12px' }}>
+      <div
+        style={{
+          fontSize: 'clamp(22px, 4vw, 28px)',
+          fontWeight: 'bold',
+          color: 'var(--accent-warm)',
+          display: 'flex',
+          alignItems: 'baseline',
+          flexWrap: 'wrap',
+          gap: '8px',
+        }}
+      >
+        <span>{monthly}</span>
+        <span style={{ fontSize: '0.45em', color: 'var(--text-secondary)', fontWeight: '600' }}>or</span>
+        <span>{annual}</span>
+      </div>
+    </div>
+  );
 }
 
 export default function SponsorDeck({
@@ -364,13 +259,23 @@ export default function SponsorDeck({
   previewTheme,
   onPreviewTheme,
   PRICE_IDS,
-  foundersClubScarcity = null,
+  foundersClubScarcity: _foundersClubScarcity = null,
   abVariant = 'A',
+  initialTab = 'investors',
 }: SponsorDeckProps) {
-  const [activeId, setActiveId] = useState('developer'); // Default to Developer Utility
+  const [activeTab, setActiveTab] = useState<SponsorPersonaTab>(initialTab);
+  /** Investors always mount on load; honour `?tier=` deep links by mounting that pane immediately. */
+  const [mountedTabs, setMountedTabs] = useState<Set<SponsorPersonaTab>>(
+    () => new Set<SponsorPersonaTab>(['investors', initialTab]),
+  );
+
+  const selectTab = useCallback((tab: SponsorPersonaTab) => {
+    setActiveTab(tab);
+    setMountedTabs((prev) => new Set(prev).add(tab));
+  }, []);
 
   const v = abVariant === 'B' ? 'B' : 'A';
-  const founderTitle = v === 'B' ? 'Unlock the AI + Risk Terminal' : 'Join the Founders Club';
+  const founderTitle = v === 'B' ? 'Unlock the AI + Risk Terminal' : 'UK Founders Club';
   const founderIntervals =
     v === 'B'
       ? [
@@ -382,331 +287,539 @@ export default function SponsorDeck({
           { label: 'Join Annual (£100/yr)', interval: 'annual' as const },
         ];
 
-  const tiers = [
-    {
-      id: 'supporter',
-      title: 'Code Supporter',
-      price: '$50',
-      priceSubtext: '/year',
-      description: 'I use the NPM packages and I support open source technologies.',
-      icon: '/brand/archetype-code-supporter.svg',
-      iconAlt: 'The Contributor',
-      color: 'var(--accent-warm)',
-      priceId: PRICE_IDS.codeSupporter,
-      tierName: 'Code Supporter',
-      expandedContent: (
-        <>
-          <div style={{ fontSize: '14px', color: '#6B7280', marginBottom: '16px', textDecoration: 'line-through', textAlign: 'center' }}>
-            $60/year if paid monthly
-          </div>
-          <div style={{ marginBottom: '12px', fontSize: '13px', color: '#f59e0b', fontWeight: '600', background: 'rgba(245, 158, 11, 0.1)', padding: '8px', borderRadius: '6px', textAlign: 'center' }}>
-            💰 Save $10/year (2 months free!)
-          </div>
-        </>
-      )
-    },
-    {
-      id: 'developer',
-      title: 'Universal Data Engine',
-      price: '$200',
-      priceSubtext: '/year',
-      description: "Don't write parsers. Push any raw broker data to our endpoint, and let our engine normalize it for you.",
-      icon: '/brand/archetype-developer-utility.svg',
-      iconAlt: 'The Builder',
-      color: 'var(--accent-warm)',
-      isPopular: true,
-      priceId: PRICE_IDS.featureVoter,
-      tierName: 'Developer Utility',
-      expandedContent: (
-        <>
-          <div style={{ fontSize: '14px', color: '#6B7280', marginBottom: '16px', textDecoration: 'line-through', textAlign: 'center' }}>
-            $240/year if paid monthly
-          </div>
-          
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ⚡ <strong>Universal Data Engine:</strong>
-            </div>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0, lineHeight: '1.8' }}>
-              Don&apos;t write parsers. Push any raw broker data to our endpoint, and let our engine normalize it for you.
-            </p>
-          </div>
+  const checkoutBusy = loading !== null;
 
-          {/* Developer Benefits */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              🚀 <strong>Developer Benefits:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Priority access to the Roadmap & Insider Discord</li>
-              <li style={{ marginBottom: '4px' }}>• Influence product development decisions</li>
-              <li style={{ marginBottom: '4px' }}>• Early access to new features</li>
-              <li style={{ marginBottom: '4px' }}>• Direct line to the development team</li>
-            </ul>
-          </div>
+  const tabBar = (
+    <div
+      role="tablist"
+      aria-label="Sponsorship persona"
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '8px',
+        marginBottom: '24px',
+        borderBottom: '1px solid var(--border-subtle, var(--border))',
+        paddingBottom: '4px',
+      }}
+    >
+      {PERSONA_TABS.map(({ id, label }) => {
+        const isActive = activeTab === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            id={`sponsor-tab-${id}`}
+            aria-controls={`sponsor-panel-${id}`}
+            onClick={() => selectTab(id)}
+            style={{
+              flex: '1 1 auto',
+              minWidth: 'min(100%, 160px)',
+              padding: '12px 20px',
+              background: isActive ? 'rgba(245, 158, 11, 0.12)' : 'transparent',
+              color: isActive ? 'var(--accent-warm)' : 'var(--text-secondary)',
+              border: 'none',
+              borderBottom: isActive ? '3px solid var(--accent-warm)' : '3px solid transparent',
+              borderRadius: '8px 8px 0 0',
+              fontSize: '14px',
+              fontWeight: isActive ? '700' : '500',
+              letterSpacing: '0.02em',
+              cursor: 'pointer',
+              transition: 'color 0.15s ease, border-color 0.15s ease, background 0.15s ease',
+              textTransform: 'none',
+            }}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
 
-          {/* API Access */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ⚡ <strong>Unlimited API Access:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Unlimited API calls (stock prices, market data)</li>
-              <li style={{ marginBottom: '4px' }}>• Real-time quote data</li>
-              <li style={{ marginBottom: '4px' }}>• Historical ticker data (JSON format)</li>
-              <li style={{ marginBottom: '4px' }}>• No rate limits or throttling</li>
-            </ul>
-          </div>
-
-          <div style={{ marginBottom: '12px', fontSize: '13px', color: '#f59e0b', fontWeight: '600', background: 'rgba(245, 158, 11, 0.1)', padding: '8px', borderRadius: '6px', textAlign: 'center' }}>
-            💰 Save $40/year (2 months free!)
-          </div>
-        </>
-      )
-    },
-    {
-      id: 'corporate',
-      title: 'Corporate Ecosystem',
-      price: '$1,000',
-      priceSubtext: '/year',
-      description: 'White Label Portal for Financial Advisors & Wealth Managers. Enterprise-grade portfolio analytics and client reporting.',
-      icon: '/brand/archetype-corporate-ecosystem.svg',
-      iconAlt: 'The Institution',
-      color: 'var(--accent-warm)',
-      priceId: PRICE_IDS.corporateSponsor,
-      tierName: 'Corporate Ecosystem',
-      expandedContent: (
-        <>
-          <div style={{ fontSize: '14px', color: '#6B7280', marginBottom: '16px', textDecoration: 'line-through', textAlign: 'center' }}>
-            $1,200/year if paid monthly
-          </div>
-          
-          {/* White Label Features */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              🏢 <strong>White Label Features:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Custom branded client dashboard</li>
-              <li style={{ marginBottom: '4px' }}>• White label PDF portfolio reports</li>
-              <li style={{ marginBottom: '4px' }}>• Firm logo integration</li>
-              <li style={{ marginBottom: '4px' }}>• Client-facing portal with your branding</li>
-            </ul>
-          </div>
-
-          {/* Corporate Perks */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ⚡ <strong>Corporate Perks:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Unlimited API calls (stock prices, market data)</li>
-              <li style={{ marginBottom: '4px' }}>• Advanced analytics (sector breakdown, Risk Matrix & Beta, stateless allocation insights)</li>
-              <li style={{ marginBottom: '4px' }}>• Priority support & onboarding</li>
-              <li style={{ marginBottom: '4px' }}>• Your logo on our README</li>
-              <li style={{ marginBottom: '4px' }}>• Early access to new features</li>
-            </ul>
-          </div>
-
-          {/* Sovereign Sync */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ✅ <strong>Sovereign Sync:</strong> Google Drive as Database (2 Seats)
-            </div>
-            <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginLeft: '20px' }}>
-              Need more? Add seats for <strong>$50/mo</strong>.
-            </div>
-          </div>
-          
-          <div style={{ marginBottom: '12px', fontSize: '13px', color: '#f59e0b', fontWeight: '600', background: 'rgba(245, 158, 11, 0.1)', padding: '8px', borderRadius: '6px', textAlign: 'center' }}>
-            💰 Save $200/year (2 months free!)
-          </div>
-        </>
-      )
-    },
-    {
-      id: 'founder',
-      title: founderTitle,
-      price: '£12/mo or £100/yr',
-      priceSubtext: '',
-      description: "You are not tied to a specific broker. Switch brokerages freely; your data history stays here. Cancel anytime.",
-      icon: '/brand/archetype-founders-club.svg',
-      iconAlt: 'The Sovereign',
-      color: '#f59e0b',
-      priceId: PRICE_IDS.foundersClub,
-      tierName: 'UK Founder\'s Club',
-      isFoundersClub: true,
-      founderCheckoutIntervals: founderIntervals,
-      expandedContent: (
-        <>
-          <div style={{ 
-            fontSize: 'clamp(12px, 2.5vw, 14px)', 
-            color: '#f59e0b', 
-            fontWeight: '600',
+  const investorsPane = (
+    <div
+      role="tabpanel"
+      id="sponsor-panel-investors"
+      aria-labelledby="sponsor-tab-investors"
+      hidden={activeTab !== 'investors'}
+      style={{
+        background: 'linear-gradient(135deg, var(--surface) 0%, rgba(245, 158, 11, 0.05) 100%)',
+        border: '2px solid var(--accent-warm)',
+        borderRadius: '12px',
+        padding: 'clamp(20px, 4vw, 32px)',
+        boxShadow: '0 4px 16px rgba(245, 158, 11, 0.2)',
+      }}
+    >
+      <div style={{ textAlign: 'center', marginBottom: '24px' }}>
+        <img
+          src="/brand/archetype-founders-club.svg"
+          alt="The Sovereign"
+          style={{ width: '80px', height: '80px', objectFit: 'contain', margin: '0 auto 16px' }}
+        />
+        <h3
+          style={{
+            fontSize: 'clamp(22px, 4vw, 28px)',
+            fontWeight: 'bold',
             marginBottom: '8px',
+            color: 'var(--text)',
+          }}
+        >
+          {founderTitle}
+        </h3>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '15px', lineHeight: 1.6, maxWidth: '560px', margin: '0 auto' }}>
+          You are not tied to a specific broker. Switch brokerages freely; your data history stays here. Cancel anytime.
+        </p>
+        <div
+          style={{
+            fontSize: 'clamp(12px, 2.5vw, 14px)',
+            color: 'var(--accent-warm)',
+            fontWeight: '600',
+            marginTop: '16px',
             textTransform: 'uppercase',
             letterSpacing: '1px',
-            textAlign: 'center'
-          }}>
-            Per month or per year — cancel anytime
-          </div>
-          
-          <ul style={{ 
-            listStyle: 'none', 
-            padding: 0, 
-            margin: '0 0 24px 0',
-            color: 'var(--text-secondary)',
-            fontSize: '14px'
-          }}>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              You are not tied to a specific broker. Switch brokerages freely; your data history stays here.
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Unlimited API calls forever
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Priority Discord access
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Permanent "Founder" badge
-              <svg 
-                width="16" 
-                height="12" 
-                viewBox="0 0 16 12" 
-                style={{ 
-                  marginLeft: '6px', 
-                  opacity: 0.7,
-                  verticalAlign: 'middle'
-                }}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect width="16" height="12" fill="#012169"/>
-                <path d="M0 0 L16 12 M16 0 L0 12" stroke="#FFFFFF" strokeWidth="2"/>
-                <path d="M8 0 L8 12 M0 6 L16 6" stroke="#FFFFFF" strokeWidth="2.5"/>
-                <path d="M0 0 L16 12 M16 0 L0 12" stroke="#C8102E" strokeWidth="1.2"/>
-                <path d="M8 0 L8 12 M0 6 L16 6" stroke="#C8102E" strokeWidth="1.5"/>
-                <path d="M0 0 L5.33 0 L0 3.56 Z" fill="#FFFFFF"/>
-                <path d="M16 0 L10.67 0 L16 3.56 Z" fill="#FFFFFF"/>
-                <path d="M0 12 L5.33 12 L0 8.44 Z" fill="#FFFFFF"/>
-                <path d="M16 12 L10.67 12 L16 8.44 Z" fill="#FFFFFF"/>
-              </svg>
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Early access to new features
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              <span>
-                <strong>Advanced Analytics:</strong> Sector breakdown, Risk Matrix & Beta analytics, and stateless allocation insights
-              </span>
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              <span>
-                <strong>🏢 White Label Portfolio Reports:</strong> Generate professional branded PDF reports with your firm logo - same value as Corporate License
-              </span>
-            </li>
-          </ul>
-          
-          <div style={{ marginBottom: '16px', padding: '12px', background: 'rgba(245, 158, 11, 0.1)', borderRadius: '8px', border: '1px solid rgba(245, 158, 11, 0.3)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: '#f59e0b', marginBottom: '8px' }}>
-              ✅ <strong>Sovereign Sync:</strong> Google Drive as Database (1 Seat)
-            </div>
-            <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginLeft: '20px' }}>
-              Need more? Add seats for <strong>£50/mo</strong>.
-            </div>
-          </div>
-        </>
-      )
-    }
-  ];
-
-  return (
-    <>
-      <style jsx global>{`
-        .sponsor-deck-scrollbar::-webkit-scrollbar {
-          width: 6px;
-        }
-        .sponsor-deck-scrollbar::-webkit-scrollbar-track {
-          background: var(--surface);
-        }
-        .sponsor-deck-scrollbar::-webkit-scrollbar-thumb {
-          background: var(--border);
-          border-radius: 3px;
-        }
-        .sponsor-deck-scrollbar::-webkit-scrollbar-thumb:hover {
-          background: var(--muted);
-        }
-        
-        /* Desktop Focus Deck */
-        @media (min-width: 1024px) {
-          .desktop-focus-deck {
-            display: block !important;
-          }
-          .mobile-sponsor-grid {
-            display: none !important;
-          }
-        }
-
-        /* Mobile Grid */
-        @media (max-width: 1023px) {
-          .desktop-focus-deck {
-            display: none !important;
-          }
-          .mobile-sponsor-grid {
-            display: grid !important;
-          }
-        }
-      `}</style>
-      
-      {/* Desktop: Horizontal Focus Deck */}
-      <div className="desktop-focus-deck" style={{ display: 'none' }}>
-        <div style={{
-          display: 'flex',
-          gap: '16px',
-          height: '600px',
-          width: '100%',
-          maxWidth: '1400px',
-          margin: '0 auto'
-        }}>
-          {tiers.map((tier) => (
-            <TierCard
-              key={tier.id}
-              id={tier.id}
-              title={tier.title}
-              price={tier.price}
-              priceSubtext={tier.priceSubtext}
-              description={tier.description}
-              icon={tier.icon}
-              iconAlt={tier.iconAlt}
-              color={tier.color}
-              isPopular={tier.isPopular}
-              isExpanded={activeId === tier.id}
-              onExpand={() => setActiveId(tier.id)}
-              onCheckout={(interval) => onCheckout(tier.priceId, tier.tierName, interval)}
-              loading={loading === (typeof tier.priceId === 'object' ? tier.priceId.annual : tier.priceId) || (typeof tier.priceId === 'object' && 'monthly' in tier.priceId && loading === tier.priceId.monthly)}
-              previewTheme={previewTheme}
-              onPreviewTheme={onPreviewTheme}
-              isFoundersClub={tier.isFoundersClub}
-              foundersClubScarcity={tier.isFoundersClub ? foundersClubScarcity ?? null : undefined}
-              founderCheckoutIntervals={'founderCheckoutIntervals' in tier ? tier.founderCheckoutIntervals : undefined}
-              priceId={tier.priceId}
-            >
-              {tier.expandedContent}
-            </TierCard>
-          ))}
+          }}
+        >
+          Per month or per year — cancel anytime
+        </div>
+        <div
+          style={{
+            fontSize: 'clamp(24px, 4.5vw, 32px)',
+            fontWeight: 'bold',
+            color: 'var(--accent-warm)',
+            marginTop: '8px',
+          }}
+        >
+          £12<span style={{ fontSize: '0.55em', fontWeight: '600' }}>/mo</span>
+          <span style={{ fontSize: '0.45em', margin: '0 8px', color: 'var(--text-secondary)' }}>or</span>
+          £100<span style={{ fontSize: '0.55em', fontWeight: '600' }}>/yr</span>
         </div>
       </div>
 
-      {/* Mobile: Vertical Stack - placeholder for existing grid */}
-      <div className="mobile-sponsor-grid" style={{ display: 'none' }}>
-        {/* Mobile cards will be rendered by the parent component */}
+      <ul
+        style={{
+          listStyle: 'none',
+          padding: 0,
+          margin: '0 0 24px 0',
+          color: 'var(--text-secondary)',
+          fontSize: '14px',
+          maxWidth: '640px',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+        }}
+      >
+        <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
+          <span style={{ color: 'var(--accent-warm)', marginRight: '8px', fontSize: '18px' }}>✓</span>
+          You are not tied to a specific broker. Switch brokerages freely; your data history stays here.
+        </li>
+        <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
+          <span style={{ color: 'var(--accent-warm)', marginRight: '8px', fontSize: '18px' }}>✓</span>
+          Unlimited API calls forever
+        </li>
+        <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
+          <span style={{ color: 'var(--accent-warm)', marginRight: '8px', fontSize: '18px' }}>✓</span>
+          Priority Discord access
+        </li>
+        <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
+          <span style={{ color: 'var(--accent-warm)', marginRight: '8px', fontSize: '18px' }}>✓</span>
+          Permanent &quot;Founder&quot; badge
+          <UkFounderBadge />
+        </li>
+        <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
+          <span style={{ color: 'var(--accent-warm)', marginRight: '8px', fontSize: '18px' }}>✓</span>
+          Early access to new features
+        </li>
+        <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'flex-start' }}>
+          <span style={{ color: 'var(--accent-warm)', marginRight: '8px', fontSize: '18px', lineHeight: 1.4 }}>✓</span>
+          <span>
+            <strong>Advanced Analytics:</strong> Sector breakdown, Risk Matrix &amp; Beta analytics, and stateless
+            allocation insights
+          </span>
+        </li>
+        <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'flex-start' }}>
+          <span style={{ color: 'var(--accent-warm)', marginRight: '8px', fontSize: '18px', lineHeight: 1.4 }}>✓</span>
+          <span>
+            <strong>🏢 White Label Portfolio Reports:</strong> Generate professional branded PDF reports with your firm
+            logo — same value as Corporate License
+          </span>
+        </li>
+      </ul>
+
+      <div
+        style={{
+          marginBottom: '16px',
+          padding: '12px',
+          background: 'rgba(245, 158, 11, 0.1)',
+          borderRadius: '8px',
+          border: '1px solid rgba(245, 158, 11, 0.3)',
+          maxWidth: '640px',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+        }}
+      >
+        <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--accent-warm)', marginBottom: '8px' }}>
+          ✅ <strong>Sovereign Sync:</strong> Google Drive as Database (1 Seat)
+        </div>
+        <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginLeft: '20px' }}>
+          Need more? Add seats for <strong>£50/mo</strong>.
+        </div>
       </div>
-    </>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '20px', maxWidth: '480px', marginLeft: 'auto', marginRight: 'auto' }}>
+        {founderIntervals.map(({ label, interval }) => (
+          <button
+            key={interval}
+            type="button"
+            onClick={() => onCheckout(PRICE_IDS.foundersClub, "UK Founder's Club", interval)}
+            disabled={checkoutBusy}
+            style={{
+              padding: '12px 24px',
+              background:
+                isPriceLoading(loading, PRICE_IDS.foundersClub) || checkoutBusy
+                  ? 'var(--muted)'
+                  : interval === 'annual'
+                    ? 'var(--accent-warm)'
+                    : 'transparent',
+              color:
+                isPriceLoading(loading, PRICE_IDS.foundersClub) || checkoutBusy
+                  ? 'var(--text-secondary)'
+                  : interval === 'annual'
+                    ? 'white'
+                    : 'var(--accent-warm)',
+              border: '2px solid var(--accent-warm)',
+              borderRadius: '8px',
+              fontSize: '14px',
+              fontWeight: '700',
+              cursor: checkoutBusy ? 'not-allowed' : 'pointer',
+              width: '100%',
+            }}
+          >
+            {isPriceLoading(loading, PRICE_IDS.foundersClub) ? 'Processing...' : label}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => onPreviewTheme(previewTheme === 'founder' ? null : 'founder')}
+          style={{
+            padding: '12px 20px',
+            background: previewTheme === 'founder' ? 'rgba(245, 158, 11, 0.2)' : 'transparent',
+            color: 'var(--accent-warm)',
+            border: '2px solid var(--accent-warm)',
+            borderRadius: '8px',
+            fontSize: '14px',
+            fontWeight: '600',
+            cursor: 'pointer',
+            width: '100%',
+          }}
+        >
+          {previewTheme === 'founder' ? '✕ Close Preview' : '✨ Preview Gold Theme'}
+        </button>
+      </div>
+    </div>
+  );
+
+  const developersPane = mountedTabs.has('developers') ? (
+    <div
+      role="tabpanel"
+      id="sponsor-panel-developers"
+      aria-labelledby="sponsor-tab-developers"
+      hidden={activeTab !== 'developers'}
+      style={{
+        display: activeTab === 'developers' ? 'grid' : 'none',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+        gap: 'clamp(16px, 3vw, 24px)',
+      }}
+    >
+      {/* Code Supporter */}
+      <div
+        style={{
+          background: 'var(--surface)',
+          border: '2px solid var(--border-subtle, var(--border))',
+          borderRadius: '12px',
+          padding: 'clamp(20px, 4vw, 28px)',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <img
+          src="/brand/archetype-code-supporter.svg"
+          alt="The Contributor"
+          style={{ width: '64px', height: '64px', objectFit: 'contain', marginBottom: '16px' }}
+        />
+        <h3 style={{ fontSize: '20px', fontWeight: 'bold', marginBottom: '8px', color: 'var(--text)' }}>
+          Code Supporter
+        </h3>
+        <DualPriceHeadline
+          monthly={<>$5<span style={{ fontSize: '0.55em' }}>/mo</span></>}
+          annual={<>$50<span style={{ fontSize: '0.55em' }}>/yr</span></>}
+        />
+        <p style={{ color: 'var(--text-secondary)', fontSize: '14px', lineHeight: 1.6, flexGrow: 1 }}>
+          I use the NPM packages and I support open source technologies.
+        </p>
+        <div
+          style={{
+            fontSize: '14px',
+            color: 'var(--text-secondary)',
+            marginBottom: '16px',
+            textDecoration: 'line-through',
+            textAlign: 'center',
+          }}
+        >
+          $60/year if paid monthly
+        </div>
+        <SavingsBanner>💰 Save $10/year (2 months free!)</SavingsBanner>
+        <BillingIntervalButtons
+          priceIds={PRICE_IDS.codeSupporter}
+          tierName="Code Supporter"
+          onCheckout={onCheckout}
+          loading={loading}
+          checkoutBusy={checkoutBusy}
+          monthlyLabel="Subscribe Monthly ($5/mo)"
+          annualLabel="Subscribe Annual ($50/yr)"
+        />
+      </div>
+
+      {/* Universal Data Engine */}
+      <div
+        style={{
+          background: 'var(--surface)',
+          border: '2px solid var(--accent-warm)',
+          borderRadius: '12px',
+          padding: 'clamp(20px, 4vw, 28px)',
+          display: 'flex',
+          flexDirection: 'column',
+          position: 'relative',
+        }}
+      >
+        <span
+          style={{
+            position: 'absolute',
+            top: '16px',
+            right: '16px',
+            background: 'var(--accent-warm)',
+            color: 'white',
+            padding: '4px 12px',
+            borderRadius: '12px',
+            fontSize: '12px',
+            fontWeight: '600',
+          }}
+        >
+          Popular
+        </span>
+        <img
+          src="/brand/archetype-developer-utility.svg"
+          alt="The Builder"
+          style={{ width: '64px', height: '64px', objectFit: 'contain', marginBottom: '16px' }}
+        />
+        <h3 style={{ fontSize: '20px', fontWeight: 'bold', marginBottom: '8px', color: 'var(--text)' }}>
+          Universal Data Engine
+        </h3>
+        <DualPriceHeadline
+          monthly={<>$20<span style={{ fontSize: '0.55em' }}>/mo</span></>}
+          annual={<>$200<span style={{ fontSize: '0.55em' }}>/yr</span></>}
+        />
+        <p style={{ color: 'var(--text-secondary)', fontSize: '14px', lineHeight: 1.6 }}>
+          Don&apos;t write parsers. Push any raw broker data to our endpoint, and let our engine normalize it for you.
+        </p>
+        <div
+          style={{
+            fontSize: '14px',
+            color: 'var(--text-secondary)',
+            margin: '12px 0 16px',
+            textDecoration: 'line-through',
+            textAlign: 'center',
+          }}
+        >
+          $240/year if paid monthly
+        </div>
+
+        <FeatureBlock title={<>⚡ <strong>Universal Data Engine:</strong></>}>
+          <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0, lineHeight: 1.8 }}>
+            Don&apos;t write parsers. Push any raw broker data to our endpoint, and let our engine normalize it for you.
+          </p>
+        </FeatureBlock>
+
+        <FeatureBlock title={<>🚀 <strong>Developer Benefits:</strong></>}>
+          <FeatureBulletList
+            items={[
+              'Priority access to the Roadmap & Insider Discord',
+              'Influence product development decisions',
+              'Early access to new features',
+              'Direct line to the development team',
+            ]}
+          />
+        </FeatureBlock>
+
+        <FeatureBlock title={<>⚡ <strong>Unlimited API Access:</strong></>}>
+          <FeatureBulletList
+            items={[
+              'Unlimited API calls (stock prices, market data)',
+              'Real-time quote data',
+              'Historical ticker data (JSON format)',
+              'No rate limits or throttling',
+            ]}
+          />
+        </FeatureBlock>
+
+        <SavingsBanner>💰 Save $40/year (2 months free!)</SavingsBanner>
+        <BillingIntervalButtons
+          priceIds={PRICE_IDS.featureVoter}
+          tierName="Developer Utility"
+          onCheckout={onCheckout}
+          loading={loading}
+          checkoutBusy={checkoutBusy}
+          monthlyLabel="Subscribe Monthly ($20/mo)"
+          annualLabel="Subscribe Annual ($200/yr)"
+        />
+      </div>
+    </div>
+  ) : null;
+
+  const institutionsPane = mountedTabs.has('institutions') ? (
+    <div
+      role="tabpanel"
+      id="sponsor-panel-institutions"
+      aria-labelledby="sponsor-tab-institutions"
+      hidden={activeTab !== 'institutions'}
+      style={{
+        background: 'var(--surface)',
+        border: '2px solid var(--border-subtle, var(--border))',
+        borderRadius: '12px',
+        padding: 'clamp(24px, 4vw, 40px)',
+        display: activeTab === 'institutions' ? 'block' : 'none',
+      }}
+    >
+      <div style={{ maxWidth: '720px', margin: '0 auto' }}>
+        <img
+          src="/brand/archetype-corporate-ecosystem.svg"
+          alt="The Institution"
+          style={{ width: '80px', height: '80px', objectFit: 'contain', marginBottom: '20px' }}
+        />
+        <h3 style={{ fontSize: 'clamp(22px, 4vw, 28px)', fontWeight: 'bold', marginBottom: '12px', color: 'var(--text)' }}>
+          Corporate Ecosystem
+        </h3>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '16px', lineHeight: 1.7, marginBottom: '16px' }}>
+          White Label Portal for Financial Advisors &amp; Wealth Managers. Enterprise-grade portfolio analytics and
+          client reporting.
+        </p>
+        <div
+          style={{
+            fontSize: '14px',
+            color: 'var(--text-secondary)',
+            marginBottom: '16px',
+            textDecoration: 'line-through',
+            textAlign: 'center',
+          }}
+        >
+          $1,200/year if paid monthly
+        </div>
+
+        <FeatureBlock title={<>🏢 <strong>White Label Features:</strong></>}>
+          <FeatureBulletList
+            items={[
+              'Custom branded client dashboard',
+              'White label PDF portfolio reports',
+              'Firm logo integration',
+              'Client-facing portal with your branding',
+            ]}
+          />
+        </FeatureBlock>
+
+        <FeatureBlock title={<>⚡ <strong>Corporate Perks:</strong></>}>
+          <FeatureBulletList
+            items={[
+              'Unlimited API calls (stock prices, market data)',
+              'Advanced analytics (sector breakdown, Risk Matrix & Beta, stateless allocation insights)',
+              'Priority support & onboarding',
+              'Your logo on our README',
+              'Early access to new features',
+            ]}
+          />
+        </FeatureBlock>
+
+        <FeatureBlock title={<>✅ <strong>Sovereign Sync:</strong> Google Drive as Database (2 Seats)</>}>
+          <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginLeft: '20px' }}>
+            Need more? Add seats for <strong>$50/mo</strong>.
+          </div>
+        </FeatureBlock>
+
+        <SavingsBanner>💰 Save $200/year (2 months free!)</SavingsBanner>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '28px' }}>
+          <Link
+            href="/tier1designpartner"
+            style={{
+              display: 'block',
+              textAlign: 'center',
+              padding: '14px 28px',
+              background: 'var(--accent-warm)',
+              color: 'white',
+              borderRadius: '8px',
+              fontSize: '16px',
+              fontWeight: '700',
+              textDecoration: 'none',
+              border: 'none',
+            }}
+          >
+            Book a Discovery Call
+          </Link>
+          <p style={{ fontSize: '13px', color: 'var(--text-secondary)', textAlign: 'center', margin: 0 }}>
+            Procurement, compliance review, and custom SLA — handled on the Tier 1 design-partner track.
+          </p>
+
+          <div
+            style={{
+              marginTop: '16px',
+              paddingTop: '20px',
+              borderTop: '1px solid var(--border-subtle, var(--border))',
+            }}
+          >
+            <p style={{ fontSize: '13px', color: 'var(--text-secondary)', marginBottom: '12px', textAlign: 'center' }}>
+              Self-serve license — subscribe below, or book a discovery call for procurement &amp; custom SLA
+            </p>
+            <DualPriceHeadline
+              monthly={<>$100<span style={{ fontSize: '0.55em' }}>/mo</span></>}
+              annual={<>$1,000<span style={{ fontSize: '0.55em' }}>/yr</span></>}
+            />
+            <BillingIntervalButtons
+              priceIds={PRICE_IDS.corporateSponsor}
+              tierName="Corporate Ecosystem"
+              onCheckout={onCheckout}
+              loading={loading}
+              checkoutBusy={checkoutBusy}
+              monthlyLabel="Subscribe Monthly ($100/mo)"
+              annualLabel="Subscribe Annual ($1,000/yr)"
+            />
+            <button
+              type="button"
+              onClick={() => onPreviewTheme(previewTheme === 'corporate' ? null : 'corporate')}
+              style={{
+                marginTop: '12px',
+                width: '100%',
+                padding: '12px 20px',
+                background: previewTheme === 'corporate' ? 'var(--muted)' : 'transparent',
+                color: 'var(--text)',
+                border: '2px solid var(--border-subtle, var(--border))',
+                borderRadius: '8px',
+                fontSize: '14px',
+                fontWeight: '500',
+                cursor: 'pointer',
+              }}
+            >
+              {previewTheme === 'corporate' ? '✕ Close Preview' : '👁️ Preview Terminal Theme'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
+  return (
+    <div style={{ width: '100%', maxWidth: '960px', margin: '0 auto' }}>
+      {tabBar}
+      {investorsPane}
+      {developersPane}
+      {institutionsPane}
+    </div>
   );
 }

--- a/app/sponsor/page.tsx
+++ b/app/sponsor/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+﻿'use client';
 
 import { loadStripe } from '@stripe/stripe-js';
 import { Suspense, useState, useEffect } from 'react';
@@ -7,7 +7,7 @@ import { useSearchParams } from 'next/navigation';
 import ProductionNavbar from '../components/marketing/ProductionNavbar';
 import SponsorModal from '../components/SponsorModal';
 import AlertModal from '../components/modals/AlertModal';
-import SponsorDeck from '../components/sponsor/SponsorDeck';
+import SponsorDeck, { resolveSponsorPersonaTab } from '../components/sponsor/SponsorDeck';
 import { getFoundersClubScarcityMessage } from '../lib/utils/foundersClub';
 import {
   trackCheckoutError,
@@ -26,7 +26,7 @@ if (!publishableKey) {
 
 // Debug: Log key info only in development (browser)
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
-  console.log('🔍 Stripe Configuration:', {
+  console.log('ðŸ” Stripe Configuration:', {
     envVarSet: !!process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
     keyPrefix: publishableKey?.substring(0, 12) + '...',
     keyType: publishableKey?.startsWith('pk_') ? 'PUBLISHABLE ✅' : publishableKey?.startsWith('sk_') ? 'SECRET ❌ (WRONG!)' : 'UNKNOWN',
@@ -69,6 +69,8 @@ function getInitialSponsorAbVariant(): 'A' | 'B' {
 function SponsorPageContent() {
   const searchParams = useSearchParams();
   const utmCampaign = searchParams?.get('utm_campaign') ?? null;
+  const tierParam = searchParams?.get('tier') ?? null;
+  const initialPersonaTab = resolveSponsorPersonaTab(tierParam) ?? 'investors';
   const [abVariant] = useState<'A' | 'B'>(getInitialSponsorAbVariant);
   const triggerSourceParam = ((searchParams?.get('trigger_source') ?? null) || 'sponsor_page_direct') as
     | 'csv_import_success'
@@ -198,7 +200,7 @@ function SponsorPageContent() {
       }
 
       // Create checkout session via API route
-      console.log('🔄 Creating checkout session for:', { priceId: finalPriceId, tierName: selectedTier.tierName });
+      console.log('ðŸ”„ Creating checkout session for:', { priceId: finalPriceId, tierName: selectedTier.tierName });
       const response = await fetch('/api/create-checkout-session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -290,17 +292,6 @@ function SponsorPageContent() {
         .founders-club-counter {
           animation: pulse-red 2s ease-in-out infinite;
         }
-        .sponsor-cards-grid {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-          gap: clamp(16px, 3vw, 24px);
-        }
-        @media (max-width: 768px) {
-          .sponsor-cards-grid {
-            grid-template-columns: 1fr;
-            gap: 20px;
-          }
-        }
       `}</style>
       <ProductionNavbar />
       <div style={{
@@ -326,13 +317,13 @@ function SponsorPageContent() {
         <p style={{
           fontSize: '1.125rem',
           color: 'var(--text-secondary)',
-          maxWidth: '600px',
+          maxWidth: '640px',
           margin: '0 auto',
           lineHeight: '1.6'
         }}>
           {abVariant === 'B'
             ? 'Advanced portfolio risk, sector analytics, and Pocket Analyst — local-first, cancel anytime.'
-            : 'Professional-grade portfolio tracking, risk analysis, and client reporting tools for wealth managers and financial advisors. Sovereign data architecture meets enterprise needs.'}
+            : 'Professional-grade portfolio tracking, risk analysis, and client reporting. Pick the tier that matches how you use Pocket Portfolio.'}
         </p>
         {/* Stripe Status Indicator */}
         {process.env.NODE_ENV === 'development' && (
@@ -353,64 +344,6 @@ function SponsorPageContent() {
         )}
       </div>
 
-      {/* WebOne Discovery Partner - Diamond Slot */}
-      <div style={{
-        background: 'linear-gradient(135deg, var(--surface) 0%, rgba(245, 158, 11, 0.05) 100%)',
-        border: '2px solid var(--border-warm)',
-        borderRadius: '16px',
-        padding: 'clamp(20px, 4vw, 32px)',
-        marginBottom: '48px',
-        textAlign: 'center',
-        width: '100%',
-        boxSizing: 'border-box'
-      }}>
-        <h2 style={{
-          fontSize: '20px',
-          fontWeight: '600',
-          marginBottom: '12px',
-          color: 'var(--text)'
-        }}>
-          Discovery Partner
-        </h2>
-        <p style={{
-          color: 'var(--text-secondary)',
-          lineHeight: '1.6',
-          marginBottom: '16px',
-          maxWidth: '600px',
-          margin: '0 auto 16px'
-        }}>
-          Special thanks to <strong>WebOne</strong> for curating Pocket Portfolio as a featured Local-First utility in their <strong>1EO Trust Library</strong>.
-        </p>
-        <a
-          href="https://www.webone.one"
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{
-            display: 'inline-block',
-            padding: '12px 24px',
-            background: 'transparent',
-            border: '2px solid var(--border-warm)',
-            borderRadius: '8px',
-            color: 'var(--accent-warm)',
-            textDecoration: 'none',
-            fontSize: '14px',
-            fontWeight: '500',
-            transition: 'all 0.2s ease'
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = 'rgba(245, 158, 11, 0.1)';
-            e.currentTarget.style.borderColor = 'var(--accent-warm)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = 'transparent';
-            e.currentTarget.style.borderColor = 'var(--border-warm)';
-          }}
-        >
-          Review on WebOne →
-        </a>
-      </div>
-
-      {/* Desktop: Focus Deck (Horizontal Accordion) */}
       <div style={{ marginBottom: '48px', width: '100%' }}>
         <SponsorDeck
           onCheckout={handleCheckout}
@@ -420,553 +353,8 @@ function SponsorPageContent() {
           PRICE_IDS={PRICE_IDS}
           foundersClubScarcity={scarcity}
           abVariant={abVariant}
+          initialTab={initialPersonaTab}
         />
-      </div>
-
-      {/* Mobile: Vertical Grid (Fallback) */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-        gap: 'clamp(16px, 3vw, 24px)',
-        marginBottom: '48px',
-        width: '100%'
-      }}
-      className="sponsor-cards-grid mobile-sponsor-grid">
-        {/* Code Supporter - $5/month */}
-        <div style={{
-          background: 'var(--surface)',
-          border: '2px solid var(--border-warm)',
-          borderRadius: '12px',
-          padding: 'clamp(20px, 4vw, 32px)',
-          display: 'flex',
-          flexDirection: 'column',
-          transition: 'transform 0.2s ease',
-          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
-          minWidth: 0,
-          width: '100%'
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = 'translateY(-4px)';
-          e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.15)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = 'translateY(0)';
-          e.currentTarget.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.1)';
-        }}
-        >
-          {/* Archetype Icon - "The Contributor" */}
-          <div style={{
-            width: '80px',
-            height: '80px',
-            margin: '0 auto 20px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}>
-            <img 
-              src="/brand/archetype-code-supporter.svg" 
-              alt="The Contributor"
-              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-            />
-          </div>
-          
-          <h3 style={{ fontSize: 'clamp(20px, 3vw, 24px)', fontWeight: 'bold', marginBottom: '8px', color: 'var(--text)' }}>
-            Code Supporter
-          </h3>
-          <div style={{ fontSize: 'clamp(28px, 5vw, 36px)', fontWeight: 'bold', color: 'var(--accent-warm)', marginBottom: '8px' }}>
-            $50<span style={{ fontSize: 'clamp(14px, 2.5vw, 18px)', color: 'var(--text-secondary)' }}>/year</span>
-          </div>
-          <div style={{ fontSize: '14px', color: '#6B7280', marginBottom: '16px', textDecoration: 'line-through' }}>
-            $60/year if paid monthly
-          </div>
-          <p style={{ color: 'var(--text-secondary)', marginBottom: '16px', flexGrow: 1, lineHeight: '1.6' }}>
-            I use the NPM packages and I support open source technologies.
-          </p>
-          <div style={{ marginBottom: '12px', fontSize: '13px', color: '#f59e0b', fontWeight: '600', background: 'rgba(245, 158, 11, 0.1)', padding: '8px', borderRadius: '6px' }}>
-            💰 Save $10/year (2 months free!)
-          </div>
-          <button
-            onClick={() => handleCheckout(PRICE_IDS.codeSupporter, 'Code Supporter')}
-            disabled={loading === PRICE_IDS.codeSupporter.annual || loading !== null}
-            style={{
-              padding: '12px 24px',
-              background: loading === PRICE_IDS.codeSupporter.annual ? 'var(--muted)' : 'var(--accent-warm)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              fontSize: '16px',
-              fontWeight: '600',
-              cursor: loading ? 'not-allowed' : 'pointer',
-              transition: 'all 0.2s ease',
-              opacity: loading && loading !== PRICE_IDS.codeSupporter.annual ? 0.6 : 1
-            }}
-          >
-            {loading === PRICE_IDS.codeSupporter.annual ? 'Processing...' : 'Subscribe (Annual)'}
-          </button>
-        </div>
-
-        {/* Developer Utility - $20/month */}
-        <div style={{
-          background: 'var(--surface)',
-          border: '2px solid var(--accent-warm)',
-          borderRadius: '12px',
-          padding: 'clamp(20px, 4vw, 32px)',
-          display: 'flex',
-          flexDirection: 'column',
-          position: 'relative',
-          transition: 'transform 0.2s ease',
-          boxShadow: '0 2px 8px rgba(245, 158, 11, 0.2)',
-          minWidth: 0,
-          width: '100%'
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = 'translateY(-4px)';
-          e.currentTarget.style.boxShadow = '0 4px 12px rgba(245, 158, 11, 0.3)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = 'translateY(0)';
-          e.currentTarget.style.boxShadow = '0 2px 8px rgba(245, 158, 11, 0.2)';
-        }}
-        >
-          <div style={{
-            position: 'absolute',
-            top: '16px',
-            right: '16px',
-            background: 'var(--accent-warm)',
-            color: 'white',
-            padding: '4px 12px',
-            borderRadius: '12px',
-            fontSize: '12px',
-            fontWeight: '600'
-          }}>
-            Popular
-          </div>
-          
-          {/* Archetype Icon - "The Builder" */}
-          <div style={{
-            width: '80px',
-            height: '80px',
-            margin: '0 auto 20px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}>
-            <img 
-              src="/brand/archetype-developer-utility.svg" 
-              alt="The Builder"
-              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-            />
-          </div>
-          
-          <h3 style={{ fontSize: 'clamp(20px, 3vw, 24px)', fontWeight: 'bold', marginBottom: '8px', color: 'var(--text)' }}>
-            Universal Data Engine
-          </h3>
-          <div style={{ fontSize: 'clamp(28px, 5vw, 36px)', fontWeight: 'bold', color: 'var(--accent-warm)', marginBottom: '8px' }}>
-            $200<span style={{ fontSize: 'clamp(14px, 2.5vw, 18px)', color: 'var(--text-secondary)' }}>/year</span>
-          </div>
-          <div style={{ fontSize: '14px', color: '#6B7280', marginBottom: '16px', textDecoration: 'line-through' }}>
-            $240/year if paid monthly
-          </div>
-          <p style={{ color: 'var(--text-secondary)', marginBottom: '16px', flexGrow: 1, lineHeight: '1.6' }}>
-            Don&apos;t write parsers. Push any raw broker data to our endpoint, and let our engine normalize it for you.
-          </p>
-          
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ⚡ <strong>Universal Data Engine:</strong>
-            </div>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0, lineHeight: '1.8' }}>
-              Don&apos;t write parsers. Push any raw broker data to our endpoint, and let our engine normalize it for you.
-            </p>
-          </div>
-
-          {/* Developer Benefits */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              🚀 <strong>Developer Benefits:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Priority access to the Roadmap & Insider Discord</li>
-              <li style={{ marginBottom: '4px' }}>• Influence product development decisions</li>
-              <li style={{ marginBottom: '4px' }}>• Early access to new features</li>
-              <li style={{ marginBottom: '4px' }}>• Direct line to the development team</li>
-            </ul>
-          </div>
-
-          {/* API Access */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ⚡ <strong>Unlimited API Access:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Unlimited API calls (stock prices, market data)</li>
-              <li style={{ marginBottom: '4px' }}>• Real-time quote data</li>
-              <li style={{ marginBottom: '4px' }}>• Historical ticker data (JSON format)</li>
-              <li style={{ marginBottom: '4px' }}>• No rate limits or throttling</li>
-            </ul>
-          </div>
-
-          <div style={{ marginBottom: '12px', fontSize: '13px', color: '#f59e0b', fontWeight: '600', background: 'rgba(245, 158, 11, 0.1)', padding: '8px', borderRadius: '6px' }}>
-            💰 Save $40/year (2 months free!)
-          </div>
-          <button
-            onClick={() => handleCheckout(PRICE_IDS.featureVoter, 'Developer Utility')}
-            disabled={loading === PRICE_IDS.featureVoter.annual || loading !== null}
-            style={{
-              padding: '12px 24px',
-              background: loading === PRICE_IDS.featureVoter.annual ? 'var(--muted)' : 'var(--accent-warm)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              fontSize: '16px',
-              fontWeight: '600',
-              cursor: loading ? 'not-allowed' : 'pointer',
-              transition: 'all 0.2s ease',
-              opacity: loading && loading !== PRICE_IDS.featureVoter.annual ? 0.6 : 1
-            }}
-          >
-            {loading === PRICE_IDS.featureVoter.annual ? 'Processing...' : 'Subscribe (Annual)'}
-          </button>
-        </div>
-
-        {/* Corporate Ecosystem - $1,000/year */}
-        <div style={{
-          background: 'var(--surface)',
-          border: '2px solid var(--border-warm)',
-          borderRadius: '12px',
-          padding: 'clamp(20px, 4vw, 32px)',
-          display: 'flex',
-          flexDirection: 'column',
-          transition: 'transform 0.2s ease',
-          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
-          minWidth: 0,
-          width: '100%'
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = 'translateY(-4px)';
-          e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.15)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = 'translateY(0)';
-          e.currentTarget.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.1)';
-        }}
-        >
-          {/* Archetype Icon - "The Institution" */}
-          <div style={{
-            width: '80px',
-            height: '80px',
-            margin: '0 auto 20px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}>
-            <img 
-              src="/brand/archetype-corporate-ecosystem.svg" 
-              alt="The Institution"
-              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-            />
-          </div>
-          
-          <h3 style={{ fontSize: 'clamp(20px, 3vw, 24px)', fontWeight: 'bold', marginBottom: '8px', color: 'var(--text)' }}>
-            Corporate Ecosystem
-          </h3>
-          <div style={{ fontSize: 'clamp(28px, 5vw, 36px)', fontWeight: 'bold', color: 'var(--accent-warm)', marginBottom: '8px' }}>
-            $1,000<span style={{ fontSize: 'clamp(14px, 2.5vw, 18px)', color: 'var(--text-secondary)' }}>/year</span>
-          </div>
-          <div style={{ fontSize: '14px', color: '#6B7280', marginBottom: '16px', textDecoration: 'line-through' }}>
-            $1,200/year if paid monthly
-          </div>
-          <p style={{ color: 'var(--text-secondary)', marginBottom: '16px', flexGrow: 1, lineHeight: '1.6' }}>
-            White Label Portal for Financial Advisors & Wealth Managers. Enterprise-grade portfolio analytics and client reporting.
-          </p>
-          
-          {/* White Label Features */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              🏢 <strong>White Label Features:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Custom branded client dashboard</li>
-              <li style={{ marginBottom: '4px' }}>• White label PDF portfolio reports</li>
-              <li style={{ marginBottom: '4px' }}>• Firm logo integration</li>
-              <li style={{ marginBottom: '4px' }}>• Client-facing portal with your branding</li>
-            </ul>
-          </div>
-
-          {/* Corporate Perks */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ⚡ <strong>Corporate Perks:</strong>
-            </div>
-            <ul style={{ fontSize: '13px', color: 'var(--text-secondary)', marginLeft: '20px', marginTop: '8px', lineHeight: '1.8', padding: 0, listStyle: 'none' }}>
-              <li style={{ marginBottom: '4px' }}>• Unlimited API calls (stock prices, market data)</li>
-              <li style={{ marginBottom: '4px' }}>• Advanced analytics (sector breakdown, Risk Matrix & Beta, stateless allocation insights)</li>
-              <li style={{ marginBottom: '4px' }}>• Priority support & onboarding</li>
-              <li style={{ marginBottom: '4px' }}>• Your logo on our README</li>
-              <li style={{ marginBottom: '4px' }}>• Early access to new features</li>
-            </ul>
-          </div>
-
-          {/* Sovereign Sync */}
-          <div style={{ marginBottom: '12px', padding: '12px', background: 'var(--surface-elevated)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: 'var(--text)', marginBottom: '8px' }}>
-              ✅ <strong>Sovereign Sync:</strong> Google Drive as Database (2 Seats)
-            </div>
-            <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginLeft: '20px' }}>
-              Need more? Add seats for <strong>$50/mo</strong>.
-            </div>
-          </div>
-          <div style={{ marginBottom: '12px', fontSize: '13px', color: '#f59e0b', fontWeight: '600', background: 'rgba(245, 158, 11, 0.1)', padding: '8px', borderRadius: '6px' }}>
-            💰 Save $200/year (2 months free!)
-          </div>
-          <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-            <button
-              onClick={() => handleCheckout(PRICE_IDS.corporateSponsor, 'Corporate Ecosystem')}
-              disabled={loading === PRICE_IDS.corporateSponsor.annual || loading !== null}
-              style={{
-                flex: '1',
-                minWidth: '140px',
-                padding: '12px 24px',
-                background: loading === PRICE_IDS.corporateSponsor.annual ? 'var(--muted)' : 'var(--accent-warm)',
-                color: 'white',
-                border: 'none',
-                borderRadius: '8px',
-                fontSize: '16px',
-                fontWeight: '600',
-                cursor: loading ? 'not-allowed' : 'pointer',
-                transition: 'all 0.2s ease',
-                opacity: loading && loading !== PRICE_IDS.corporateSponsor.annual ? 0.6 : 1
-              }}
-            >
-              {loading === PRICE_IDS.corporateSponsor.annual ? 'Processing...' : 'Subscribe (Annual)'}
-            </button>
-            <button
-              onClick={() => setPreviewTheme(previewTheme === 'corporate' ? null : 'corporate')}
-              style={{
-                padding: '12px 20px',
-                background: previewTheme === 'corporate' ? 'var(--muted)' : 'transparent',
-                color: previewTheme === 'corporate' ? 'var(--text)' : 'var(--text)',
-                border: '2px solid var(--border-warm)',
-                borderRadius: '8px',
-                fontSize: '14px',
-                fontWeight: '500',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px'
-              }}
-            >
-              {previewTheme === 'corporate' ? '✕ Close Preview' : '👁️ Preview Terminal Theme'}
-            </button>
-          </div>
-        </div>
-
-        {/* UK Founder's Club - £12/mo or £100/yr subscription */}
-        <div style={{
-          background: 'linear-gradient(135deg, var(--surface) 0%, rgba(245, 158, 11, 0.05) 100%)',
-          border: '3px solid #f59e0b', // Gold/Amber border
-          borderRadius: '12px',
-          padding: 'clamp(20px, 4vw, 32px)',
-          display: 'flex',
-          flexDirection: 'column',
-          position: 'relative',
-          transition: 'transform 0.2s ease',
-          boxShadow: '0 4px 16px rgba(245, 158, 11, 0.3)',
-          minWidth: 0,
-          width: '100%'
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = 'translateY(-4px)';
-          e.currentTarget.style.boxShadow = '0 8px 24px rgba(245, 158, 11, 0.4)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = 'translateY(0)';
-          e.currentTarget.style.boxShadow = '0 4px 16px rgba(245, 158, 11, 0.3)';
-        }}
-        >
-          {/* Archetype Icon - "The Sovereign" */}
-          <div style={{
-            width: '80px',
-            height: '80px',
-            margin: '0 auto 20px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}>
-            <img 
-              src="/brand/archetype-founders-club.svg" 
-              alt="The Sovereign"
-              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-            />
-          </div>
-
-          <h3 style={{ 
-            fontSize: 'clamp(22px, 4vw, 28px)', 
-            fontWeight: 'bold', 
-            marginBottom: '8px', 
-            color: 'var(--text)',
-            marginTop: '0'
-          }}>
-            UK FOUNDER'S CLUB
-          </h3>
-          <div style={{ 
-            fontSize: 'clamp(12px, 2.5vw, 14px)', 
-            color: '#f59e0b', 
-            fontWeight: '600',
-            marginBottom: '8px',
-            textTransform: 'uppercase',
-            letterSpacing: '1px'
-          }}>
-            Per month or per year — cancel anytime
-          </div>
-          <div style={{ fontSize: 'clamp(24px, 4.5vw, 32px)', fontWeight: 'bold', color: '#f59e0b', marginBottom: '8px', display: 'flex', alignItems: 'baseline', flexWrap: 'wrap', gap: '8px', justifyContent: 'center' }}>
-            <span>£12<span style={{ fontSize: '0.85em', fontWeight: '600', opacity: 0.9 }}>/mo</span></span>
-            <span style={{ color: '#f59e0b', fontWeight: 'bold', fontSize: '1em' }}>or</span>
-            <span>£100<span style={{ fontSize: '0.85em', fontWeight: '600', opacity: 0.9 }}>/yr</span></span>
-          </div>
-          <div style={{ fontSize: '13px', color: 'var(--text-secondary)', marginBottom: '16px' }}>
-            Save vs monthly with annual (billed yearly)
-          </div>
-          <p style={{ color: 'var(--text-secondary)', marginBottom: '16px', flexGrow: 1, lineHeight: '1.6', fontSize: '15px' }}>
-            You are not tied to a specific broker. Switch brokerages freely; your data history stays here.
-          </p>
-          <ul style={{ 
-            listStyle: 'none', 
-            padding: 0, 
-            margin: '0 0 24px 0',
-            color: 'var(--text-secondary)',
-            fontSize: '14px'
-          }}>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Unlimited API calls forever
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Priority Discord access
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Permanent "Founder" badge
-              {/* Subtle British Flag Icon */}
-              <svg 
-                width="16" 
-                height="12" 
-                viewBox="0 0 16 12" 
-                style={{ 
-                  marginLeft: '6px', 
-                  opacity: 0.7,
-                  verticalAlign: 'middle'
-                }}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                {/* Union Jack simplified - red cross on white, blue background */}
-                <rect width="16" height="12" fill="#012169"/>
-                <path d="M0 0 L16 12 M16 0 L0 12" stroke="#FFFFFF" strokeWidth="2"/>
-                <path d="M8 0 L8 12 M0 6 L16 6" stroke="#FFFFFF" strokeWidth="2.5"/>
-                <path d="M0 0 L16 12 M16 0 L0 12" stroke="#C8102E" strokeWidth="1.2"/>
-                <path d="M8 0 L8 12 M0 6 L16 6" stroke="#C8102E" strokeWidth="1.5"/>
-                <path d="M0 0 L5.33 0 L0 3.56 Z" fill="#FFFFFF"/>
-                <path d="M16 0 L10.67 0 L16 3.56 Z" fill="#FFFFFF"/>
-                <path d="M0 12 L5.33 12 L0 8.44 Z" fill="#FFFFFF"/>
-                <path d="M16 12 L10.67 12 L16 8.44 Z" fill="#FFFFFF"/>
-              </svg>
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              Early access to new features
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              <span>
-                <strong>Advanced Analytics:</strong> Sector breakdown, Risk Matrix & Beta analytics, and stateless allocation insights
-              </span>
-            </li>
-            <li style={{ marginBottom: '8px', display: 'flex', alignItems: 'center' }}>
-              <span style={{ color: '#f59e0b', marginRight: '8px', fontSize: '18px' }}>✓</span>
-              <span>
-                <strong>🏢 White Label Portfolio Reports:</strong> Generate professional branded PDF reports with your firm logo - same value as Corporate License
-              </span>
-            </li>
-          </ul>
-          <div style={{ marginBottom: '16px', padding: '12px', background: 'rgba(245, 158, 11, 0.1)', borderRadius: '8px', border: '1px solid rgba(245, 158, 11, 0.3)' }}>
-            <div style={{ fontSize: '14px', fontWeight: '600', color: '#f59e0b', marginBottom: '8px' }}>
-              ✅ <strong>Sovereign Sync:</strong> Google Drive as Database (1 Seat)
-            </div>
-            <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginLeft: '20px' }}>
-              Need more? Add seats for <strong>£50/mo</strong>.
-            </div>
-          </div>
-          <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-            <button
-              onClick={() => handleCheckout(PRICE_IDS.foundersClub, "UK Founder's Club", 'annual')}
-              disabled={loading === PRICE_IDS.foundersClub.annual || loading === PRICE_IDS.foundersClub.monthly || loading !== null}
-              style={{
-                flex: '1',
-                minWidth: 'clamp(120px, 25vw, 160px)',
-                padding: 'clamp(12px, 3vw, 16px) clamp(16px, 4vw, 24px)',
-                background: (loading === PRICE_IDS.foundersClub.annual || loading === PRICE_IDS.foundersClub.monthly) ? 'var(--muted)' : 'linear-gradient(135deg, #f59e0b 0%, #d97706 100%)',
-                color: 'white',
-                border: 'none',
-                borderRadius: '8px',
-                fontSize: 'clamp(13px, 2.5vw, 16px)',
-                fontWeight: '700',
-                cursor: loading ? 'not-allowed' : 'pointer',
-                transition: 'all 0.2s ease',
-                opacity: loading && loading !== PRICE_IDS.foundersClub.annual && loading !== PRICE_IDS.foundersClub.monthly ? 0.6 : 1,
-                boxShadow: loading ? 'none' : '0 4px 12px rgba(245, 158, 11, 0.4)',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}
-            >
-              {(loading === PRICE_IDS.foundersClub.annual || loading === PRICE_IDS.foundersClub.monthly) ? 'Processing...' : 'Join Annual (£100/yr)'}
-            </button>
-            <button
-              onClick={() => handleCheckout(PRICE_IDS.foundersClub, "UK Founder's Club", 'monthly')}
-              disabled={loading === PRICE_IDS.foundersClub.annual || loading === PRICE_IDS.foundersClub.monthly || loading !== null}
-              style={{
-                flex: '1',
-                minWidth: 'clamp(120px, 25vw, 160px)',
-                padding: 'clamp(12px, 3vw, 16px) clamp(16px, 4vw, 24px)',
-                background: (loading === PRICE_IDS.foundersClub.annual || loading === PRICE_IDS.foundersClub.monthly) ? 'var(--muted)' : 'var(--surface-elevated)',
-                color: '#f59e0b',
-                border: '2px solid #f59e0b',
-                borderRadius: '8px',
-                fontSize: 'clamp(13px, 2.5vw, 16px)',
-                fontWeight: '700',
-                cursor: loading ? 'not-allowed' : 'pointer',
-                transition: 'all 0.2s ease',
-                opacity: loading && loading !== PRICE_IDS.foundersClub.annual && loading !== PRICE_IDS.foundersClub.monthly ? 0.6 : 1,
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}
-            >
-              Join Monthly (£12/mo)
-            </button>
-            <button
-              onClick={() => setPreviewTheme(previewTheme === 'founder' ? null : 'founder')}
-              style={{
-                padding: '16px 24px',
-                background: previewTheme === 'founder' ? 'rgba(245, 158, 11, 0.2)' : 'transparent',
-                color: previewTheme === 'founder' ? '#f59e0b' : '#f59e0b',
-                border: '2px solid #f59e0b',
-                borderRadius: '8px',
-                fontSize: '14px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}
-            >
-              {previewTheme === 'founder' ? '✕ Close Preview' : '✨ Preview Gold Theme'}
-            </button>
-          </div>
-        </div>
       </div>
 
     </div>

--- a/tests/e2e/dual-surface/open-sponsor-persona-tabs.spec.ts
+++ b/tests/e2e/dual-surface/open-sponsor-persona-tabs.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * CMD-UI-SPONSOR-2026-06-10 — Sponsor persona tabs E2E (Open B2B surface).
+ * Project: dual-surface-open (open.localhost:3001)
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Sponsor persona tabs — Open B2B surface', () => {
+  test('loads /sponsor with investors tab active by default', async ({ page }) => {
+    const res = await page.goto('/sponsor');
+    expect(res?.status()).toBe(200);
+
+    await expect(page.getByRole('tab', { name: 'For investors' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.locator('#sponsor-panel-investors')).toBeVisible();
+    await expect(page.getByText('Unlimited API calls forever')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Join Monthly/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Join Annual/i })).toBeVisible();
+  });
+
+  test('does not show removed WebOne block or implementation meta-copy', async ({ page }) => {
+    await page.goto('/sponsor');
+    await expect(page.getByText('Discovery Partner')).toHaveCount(0);
+    await expect(page.getByText(/mixed-tier carousel/i)).toHaveCount(0);
+  });
+
+  test('lazy-mounts developers pane only after tab click', async ({ page }) => {
+    await page.goto('/sponsor');
+    await expect(page.locator('#sponsor-panel-developers')).toHaveCount(0);
+
+    await page.getByRole('tab', { name: 'For developers' }).click();
+    await expect(page.locator('#sponsor-panel-developers')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Universal Data Engine' })).toBeVisible();
+    await expect(page.getByText('Unlimited API Access:')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Subscribe Monthly ($5/mo)' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Subscribe Annual ($200/yr)' })).toBeVisible();
+  });
+
+  test('lazy-mounts institutions pane only after tab click', async ({ page }) => {
+    await page.goto('/sponsor');
+    await expect(page.locator('#sponsor-panel-institutions')).toHaveCount(0);
+
+    await page.getByRole('tab', { name: 'For institutions' }).click();
+    await expect(page.locator('#sponsor-panel-institutions')).toBeVisible();
+    await expect(page.getByText('White Label Features:')).toBeVisible();
+    await expect(page.getByText('Corporate Perks:')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Book a Discovery Call' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Subscribe Monthly ($100/mo)' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Subscribe Annual ($1,000/yr)' })).toBeVisible();
+  });
+
+  test('?tier=corporate deep link opens institutions pane on load', async ({ page }) => {
+    await page.goto('/sponsor?tier=corporate');
+    await expect(page.getByRole('tab', { name: 'For institutions' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.locator('#sponsor-panel-institutions')).toBeVisible();
+    await expect(page.getByText('Corporate Ecosystem')).toBeVisible();
+  });
+
+  test('?tier=founder deep link opens investors pane on load', async ({ page }) => {
+    await page.goto('/sponsor?tier=founder');
+    await expect(page.getByRole('tab', { name: 'For investors' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByText('Permanent "Founder" badge')).toBeVisible();
+  });
+
+  test('?tier=developer-utility deep link opens developers pane on load', async ({ page }) => {
+    await page.goto('/sponsor?tier=developer-utility');
+    await expect(page.getByRole('tab', { name: 'For developers' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.locator('#sponsor-panel-developers')).toBeVisible();
+    await expect(page.getByText('Developer Benefits:')).toBeVisible();
+  });
+
+  test('uses Open Portfolio chrome on Open host', async ({ page }) => {
+    await page.goto('/sponsor');
+    await expect(page.locator('header.open-brand-header')).toBeVisible();
+    await expect(page.locator('header.open-brand-header')).toContainText(/Open Portfolio/i);
+  });
+});

--- a/tests/e2e/dual-surface/pocket-sponsor-persona-tabs.spec.ts
+++ b/tests/e2e/dual-surface/pocket-sponsor-persona-tabs.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * CMD-UI-SPONSOR-2026-06-10 — Sponsor route Pocket host boundary checks.
+ * Project: dual-surface-pocket (localhost:3001)
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Sponsor route — Pocket B2C host boundary', () => {
+  test('Pocket host serves sponsor without Open-only 404', async ({ page }) => {
+    const res = await page.goto('/sponsor');
+    expect(res?.status()).toBe(200);
+    await expect(page.getByRole('tab', { name: 'For investors' })).toBeVisible();
+  });
+
+  test('Pocket host does not use Open brand header chrome', async ({ page }) => {
+    await page.goto('/sponsor');
+    await expect(page.locator('header.open-brand-header')).toHaveCount(0);
+  });
+});

--- a/tests/unit/sponsor-persona-tabs.spec.ts
+++ b/tests/unit/sponsor-persona-tabs.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSponsorPersonaTab } from '@/app/components/sponsor/SponsorDeck';
+
+describe('resolveSponsorPersonaTab', () => {
+  it('defaults unknown tiers to null (caller uses investors)', () => {
+    expect(resolveSponsorPersonaTab(null)).toBeNull();
+    expect(resolveSponsorPersonaTab('')).toBeNull();
+    expect(resolveSponsorPersonaTab('unknown')).toBeNull();
+  });
+
+  it('maps legacy tier deep links to persona panes', () => {
+    expect(resolveSponsorPersonaTab('founder')).toBe('investors');
+    expect(resolveSponsorPersonaTab('code-supporter')).toBe('developers');
+    expect(resolveSponsorPersonaTab('developer-utility')).toBe('developers');
+    expect(resolveSponsorPersonaTab('corporate')).toBe('institutions');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **CMD-UI-SPONSOR-2026-06-10**: replaces the sponsor page horizontal carousel with three intent-based persona panes (investors / developers / institutions) while preserving **1:1 Stripe price ID mapping** for all four tiers.

- Default active pane: **For investors** (Founders Club)
- Lazy-mount developers and institutions panes on first tab click
- `?tier=` deep links map to correct pane (with mount-on-load fix)
- Full original tier product copy restored; WebOne block and implementation meta-copy removed
- Monthly + annual CTAs on all paid tiers

## Automated gates (local)

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build` — pass
- `npx vitest run tests/unit/sponsor-persona-tabs.spec.ts` — pass
- `npm run e2e:dual-surface` (sponsor specs) — **10/10 pass**

## Production status

**PRODUCTION DEPLOY BLOCKED** per CEO mandate. This PR is for **staging verification only**.

### Required before production lift

1. **Stripe smoke matrix (8 paths)** on staging with test mode: Code Supporter, Developer Utility, Corporate, Founders Club x monthly/annual
2. **Cross-host visual QA**: open.localhost:3001/sponsor vs localhost:3001/sponsor
3. **Analytics**: confirm checkout_start fires with correct tierName and billing_interval
4. **CPO narrative sign-off**: Founders Club A/B headline vs bounded aggregate context
5. **CEO sign-off** after green staging report

## Test plan

- [ ] Open staging /sponsor — investors tab default
- [ ] Tab switch + lazy mount (developers, institutions)
- [ ] Deep links: tier=corporate, tier=founder, tier=developer-utility
- [ ] All 8 Stripe checkout paths complete in test mode
- [ ] Open chrome on openportfolio.co.uk/sponsor; Pocket redirect from pocketportfolio.app/sponsor
- [ ] CI Playwright dual-surface job green
