### PR TITLE
feat: internal feedback system (Spec: 34ae50c3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,11 @@ VITE_FIREBASE_PROJECT_ID=
 # Optional caps: VIRAL_MOMENT_BLAST_MAX_SENDS=50 VIRAL_MOMENT_BLAST_MAX_EVALUATED=5000
 # Optional from override (defaults in lib/marketing): VIRAL_ROUTE_TO_RISE_FROM=
 # EMAIL_LOGO_URL=
+
+# Feedback substrate (Phase 1)
+# Sole operational inbox (P0 TO + default From): ai@pocketportfolio.app
+# FEEDBACK_ENGINEERING_EMAIL=ai@pocketportfolio.app
+# FEEDBACK_ALERT_FROM=Pocket Portfolio Alerts <ai@pocketportfolio.app>
+# FEEDBACK_ANON_PEPPER=  # prod: set distinct pepper; local may fall back to ENCRYPTION_SECRET
+# FEEDBACK_P0_WEBHOOK_URL=  # optional Slack/Discord for P0 alerts
+# NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS=  # local/dev only — OMIT in Vercel production

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -228,6 +228,15 @@ export default function AdminAnalyticsPage() {
   const [checkingAdmin, setCheckingAdmin] = useState(true);
   const [manualRefresh, setManualRefresh] = useState(0);
 
+  // Feedback substrate (Phase 1) — fetched from dedicated admin routes (Bearer token).
+  const [feedbackSubmissions, setFeedbackSubmissions] = useState<any[]>([]);
+  const [feedbackAlerts, setFeedbackAlerts] = useState<any[]>([]);
+  const [featuredPocket, setFeaturedPocket] = useState<any[]>([]);
+  const [featuredOpen, setFeaturedOpen] = useState<any[]>([]);
+  const [feedbackLoading, setFeedbackLoading] = useState(false);
+  const [feedbackError, setFeedbackError] = useState<string | null>(null);
+  const [curateBusyId, setCurateBusyId] = useState<string | null>(null);
+
   // Check admin status
   useEffect(() => {
     const checkAdmin = async () => {
@@ -288,6 +297,85 @@ export default function AdminAnalyticsPage() {
     }
   }, [isAdmin, checkingAdmin, timeRange]);
 
+  const fetchFeedbackData = useCallback(async () => {
+    if (!isAdmin || checkingAdmin || !user) return;
+    try {
+      setFeedbackLoading(true);
+      setFeedbackError(null);
+      const token = await user.getIdToken(true);
+
+      const [subsRes, alertsRes, pocketRes, openRes] = await Promise.all([
+        fetch(`/api/admin/feedback/submissions?limit=200&_=${Date.now()}`, {
+          headers: { Authorization: `Bearer ${token}` },
+          cache: 'no-store',
+        }),
+        fetch(`/api/admin/feedback/alerts?limit=200&_=${Date.now()}`, {
+          headers: { Authorization: `Bearer ${token}` },
+          cache: 'no-store',
+        }),
+        fetch(`/api/feedback/featured?surface=pocket&_=${Date.now()}`, { cache: 'no-store' }),
+        fetch(`/api/feedback/featured?surface=open&_=${Date.now()}`, { cache: 'no-store' }),
+      ]);
+
+      const subsJson = await subsRes.json().catch(() => ({}));
+      const alertsJson = await alertsRes.json().catch(() => ({}));
+      const pocketJson = await pocketRes.json().catch(() => ({}));
+      const openJson = await openRes.json().catch(() => ({}));
+
+      const errors: string[] = [];
+      if (!subsRes.ok) errors.push(subsJson?.error ?? 'Failed to load feedback submissions');
+      else setFeedbackSubmissions(Array.isArray(subsJson?.submissions) ? subsJson.submissions : []);
+
+      if (!alertsRes.ok) errors.push(alertsJson?.error ?? 'Failed to load feedback alerts');
+      else setFeedbackAlerts(Array.isArray(alertsJson?.alerts) ? alertsJson.alerts : []);
+
+      if (!pocketRes.ok) errors.push(pocketJson?.error ?? 'Failed to load featured receipts (pocket)');
+      else setFeaturedPocket(Array.isArray(pocketJson?.receipts) ? pocketJson.receipts : []);
+
+      if (!openRes.ok) errors.push(openJson?.error ?? 'Failed to load featured receipts (open)');
+      else setFeaturedOpen(Array.isArray(openJson?.receipts) ? openJson.receipts : []);
+
+      setFeedbackError(errors.length ? errors.join(' · ') : null);
+    } catch (e: any) {
+      setFeedbackError(e?.message ?? 'Failed to load feedback');
+    } finally {
+      setFeedbackLoading(false);
+    }
+  }, [isAdmin, checkingAdmin, user]);
+
+  async function curateReceipt(params: {
+    action: 'create' | 'update' | 'unfeature';
+    surface: 'pocket' | 'open';
+    receiptId?: string;
+    submissionId?: string;
+    quote?: string;
+    tagline?: string | null;
+    rating?: number | null;
+    expiresAt?: string | null;
+  }) {
+    if (!user) return;
+    try {
+      setFeedbackError(null);
+      setCurateBusyId(params.receiptId ?? 'new');
+      const token = await user.getIdToken(true);
+      const res = await fetch('/api/admin/feedback/curate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(params),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json?.error ?? 'Failed to curate');
+      await fetchFeedbackData();
+    } catch (e: any) {
+      setFeedbackError(e?.message ?? 'Failed to curate');
+    } finally {
+      setCurateBusyId(null);
+    }
+  }
+
   // Fetch analytics data — near–real-time poll + manual refresh
   useEffect(() => {
     if (!isAdmin || checkingAdmin) {
@@ -295,6 +383,7 @@ export default function AdminAnalyticsPage() {
     }
 
     void fetchAnalyticsData();
+    void fetchFeedbackData();
 
     // Long interval: admin dashboard previously polled every 45s and contributed to Firestore read spikes.
     const intervalMs = 10 * 60 * 1000;
@@ -302,7 +391,7 @@ export default function AdminAnalyticsPage() {
       void fetchAnalyticsData();
     }, intervalMs);
     return () => clearInterval(interval);
-  }, [isAdmin, checkingAdmin, timeRange, manualRefresh, fetchAnalyticsData]);
+  }, [isAdmin, checkingAdmin, timeRange, manualRefresh, fetchAnalyticsData, fetchFeedbackData]);
 
   // Show loading while checking auth
   if (loading || checkingAdmin) {
@@ -923,6 +1012,440 @@ export default function AdminAnalyticsPage() {
                     : 0
                 }
               />
+            </div>
+          </section>
+
+          {/* Feedback Substrate (Phase 1) */}
+          <section
+            style={{
+              background: 'var(--surface)',
+              border: '1px solid var(--border)',
+              borderRadius: '12px',
+              padding: 'var(--space-6)',
+            }}
+          >
+            <h2
+              style={{
+                fontSize: '20px',
+                fontWeight: 'bold',
+                marginBottom: 'var(--space-2)',
+                color: 'var(--text)',
+              }}
+            >
+              🧪 Feedback Substrate
+            </h2>
+            <p style={{ fontSize: '14px', color: 'var(--text-secondary)', marginBottom: 'var(--space-4)' }}>
+              Power-user signal intake (scrubbed) → P0 router (write-path) → CMS receipts → public landings.
+              Promoting copies a curated excerpt to the public index; the scrubbed vault record stays for audit.
+            </p>
+
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+                gap: 'var(--space-3)',
+                marginBottom: 'var(--space-4)',
+              }}
+            >
+              <MetricCard
+                label="Submissions"
+                value={String(feedbackSubmissions.length)}
+                subtitle="feedbackSubmissions vault"
+              />
+              <MetricCard
+                label="P0 alerts"
+                value={String(feedbackAlerts.length)}
+                subtitle="feedbackAlertDeliveries"
+              />
+              <MetricCard
+                label="Featured (Pocket)"
+                value={String(featuredPocket.length)}
+                subtitle="public /landing"
+              />
+              <MetricCard
+                label="Featured (Open)"
+                value={String(featuredOpen.length)}
+                subtitle="public /open"
+              />
+            </div>
+
+            <div style={{ display: 'flex', gap: '10px', alignItems: 'center', flexWrap: 'wrap', marginBottom: 'var(--space-4)' }}>
+              <button
+                onClick={() => void fetchFeedbackData()}
+                style={{
+                  padding: '8px 14px',
+                  borderRadius: '8px',
+                  border: '1px solid var(--border)',
+                  background: 'transparent',
+                  color: 'var(--text)',
+                  cursor: 'pointer',
+                  fontWeight: 600,
+                }}
+              >
+                Refresh feedback
+              </button>
+              {feedbackLoading && <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>Loading…</span>}
+              {feedbackError && <span style={{ fontSize: '12px', color: 'var(--danger)' }}>{feedbackError}</span>}
+            </div>
+
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
+                gap: 'var(--space-4)',
+                alignItems: 'start',
+              }}
+            >
+              <div style={{ border: '1px solid var(--border)', borderRadius: '10px', overflow: 'hidden' }}>
+                <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--border)', fontWeight: 700 }}>
+                  Submissions (latest)
+                </div>
+                <div style={{ maxHeight: '420px', overflow: 'auto' }}>
+                  {(() => {
+                    const awaiting = feedbackSubmissions.filter(
+                      (s) => !s?.featuredReceiptIds?.pocket && !s?.featuredReceiptIds?.open
+                    );
+                    const curated = feedbackSubmissions.filter(
+                      (s) => s?.featuredReceiptIds?.pocket || s?.featuredReceiptIds?.open
+                    );
+
+                    const renderSubmissionCard = (
+                      s: any,
+                      opts: { curated: boolean }
+                    ) => {
+                      const onPocket = !!s?.featuredReceiptIds?.pocket;
+                      const onOpen = !!s?.featuredReceiptIds?.open;
+                      return (
+                        <div
+                          key={s.id}
+                          style={{
+                            padding: '12px 14px',
+                            borderBottom: '1px solid var(--border)',
+                            background: opts.curated
+                              ? 'color-mix(in srgb, var(--surface) 82%, black)'
+                              : 'color-mix(in srgb, var(--surface) 92%, black)',
+                            opacity: opts.curated ? 0.88 : 1,
+                          }}
+                        >
+                          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
+                            <div style={{ fontSize: '13px', fontWeight: 700 }}>
+                              {s.category ?? '—'} · {s.rating ?? '—'}/5 · {s.friction ?? '—'}
+                            </div>
+                            <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                              {s.createdAt ? new Date(s.createdAt).toLocaleString('en-GB') : '—'}
+                            </div>
+                          </div>
+                          <div style={{ marginTop: '6px', fontSize: '12px', color: 'var(--text-secondary)' }}>
+                            anon: <code>{String(s.anonUserHash ?? '').slice(0, 14)}…</code> · tier: {s.tierBand ?? '—'}
+                          </div>
+                          {(onPocket || onOpen) && (
+                            <div style={{ marginTop: '8px', display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                              {onPocket && (
+                                <span
+                                  style={{
+                                    fontSize: '11px',
+                                    fontWeight: 700,
+                                    padding: '3px 8px',
+                                    borderRadius: '999px',
+                                    border: '1px solid var(--accent-warm)',
+                                    color: 'var(--accent-warm)',
+                                  }}
+                                >
+                                  Featured on Pocket
+                                </span>
+                              )}
+                              {onOpen && (
+                                <span
+                                  style={{
+                                    fontSize: '11px',
+                                    fontWeight: 700,
+                                    padding: '3px 8px',
+                                    borderRadius: '999px',
+                                    border: '1px solid var(--border)',
+                                    color: 'var(--text-secondary)',
+                                  }}
+                                >
+                                  Featured on Open
+                                </span>
+                              )}
+                            </div>
+                          )}
+                          <div style={{ marginTop: '8px', fontSize: '13px', lineHeight: 1.45, whiteSpace: 'pre-wrap' }}>
+                            {(s.commentScrubbed ?? '').slice(0, 240)}
+                            {(s.commentScrubbed ?? '').length > 240 ? '…' : ''}
+                          </div>
+                          {(!onPocket || !onOpen) && (
+                            <div style={{ marginTop: '10px', display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                              {!onPocket && (
+                                <button
+                                  onClick={() =>
+                                    void curateReceipt({
+                                      action: 'create',
+                                      surface: 'pocket',
+                                      submissionId: s.id,
+                                      quote: String(s.commentScrubbed ?? '').slice(0, 320),
+                                      tagline: String(s.category ?? '').slice(0, 120) || null,
+                                      rating: typeof s.rating === 'number' ? s.rating : null,
+                                      expiresAt: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString(),
+                                    })
+                                  }
+                                  disabled={curateBusyId === 'new'}
+                                  style={{
+                                    padding: '8px 10px',
+                                    borderRadius: '8px',
+                                    border: '1px solid var(--accent-warm)',
+                                    background: 'var(--accent-warm)',
+                                    color: '#0f1216',
+                                    cursor: 'pointer',
+                                    fontWeight: 800,
+                                  }}
+                                >
+                                  Promote → Pocket
+                                </button>
+                              )}
+                              {!onOpen && (
+                                <button
+                                  onClick={() =>
+                                    void curateReceipt({
+                                      action: 'create',
+                                      surface: 'open',
+                                      submissionId: s.id,
+                                      quote: String(s.commentScrubbed ?? '').slice(0, 320),
+                                      tagline: String(s.category ?? '').slice(0, 120) || null,
+                                      rating: typeof s.rating === 'number' ? s.rating : null,
+                                      expiresAt: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString(),
+                                    })
+                                  }
+                                  disabled={curateBusyId === 'new'}
+                                  style={{
+                                    padding: '8px 10px',
+                                    borderRadius: '8px',
+                                    border: '1px solid var(--border)',
+                                    background: 'transparent',
+                                    color: 'var(--text)',
+                                    cursor: 'pointer',
+                                    fontWeight: 700,
+                                  }}
+                                >
+                                  Promote → Open
+                                </button>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    };
+
+                    return (
+                      <>
+                        {awaiting.length > 0 && (
+                          <div
+                            style={{
+                              padding: '8px 14px',
+                              fontSize: '11px',
+                              fontWeight: 700,
+                              letterSpacing: '0.04em',
+                              textTransform: 'uppercase',
+                              color: 'var(--text-secondary)',
+                              borderBottom: '1px solid var(--border)',
+                              background: 'color-mix(in srgb, var(--surface) 96%, black)',
+                            }}
+                          >
+                            Awaiting curation ({awaiting.length})
+                          </div>
+                        )}
+                        {awaiting.map((s) => renderSubmissionCard(s, { curated: false }))}
+                        {curated.length > 0 && (
+                          <div
+                            style={{
+                              padding: '8px 14px',
+                              fontSize: '11px',
+                              fontWeight: 700,
+                              letterSpacing: '0.04em',
+                              textTransform: 'uppercase',
+                              color: 'var(--text-secondary)',
+                              borderBottom: '1px solid var(--border)',
+                              borderTop: awaiting.length > 0 ? '1px solid var(--border)' : undefined,
+                              background: 'color-mix(in srgb, var(--surface) 96%, black)',
+                            }}
+                          >
+                            Curated — vault copy retained ({curated.length})
+                          </div>
+                        )}
+                        {curated.map((s) => renderSubmissionCard(s, { curated: true }))}
+                      </>
+                    );
+                  })()}
+                  {feedbackSubmissions.length === 0 && (
+                    <div style={{ padding: '12px 14px', color: 'var(--text-secondary)' }}>No submissions yet.</div>
+                  )}
+                </div>
+              </div>
+
+              <div style={{ display: 'grid', gap: 'var(--space-4)' }}>
+                <div style={{ border: '1px solid var(--border)', borderRadius: '10px', overflow: 'hidden' }}>
+                  <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--border)', fontWeight: 700 }}>
+                    Featured receipts — Pocket (public)
+                  </div>
+                  <div style={{ maxHeight: '220px', overflow: 'auto' }}>
+                    {featuredPocket.map((r) => (
+                      <div key={r.id} style={{ padding: '10px 14px', borderBottom: '1px solid var(--border)' }}>
+                        <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                          {r.tagline ?? '—'} {typeof r.rating === 'number' ? `· ${r.rating}/5` : ''}
+                        </div>
+                        <div style={{ marginTop: '6px', fontSize: '13px', whiteSpace: 'pre-wrap' }}>
+                          {String(r.quote ?? '').slice(0, 220)}
+                          {String(r.quote ?? '').length > 220 ? '…' : ''}
+                        </div>
+                        <div style={{ marginTop: '8px', display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                          <button
+                            onClick={() => {
+                              const nextQuote = window.prompt('Edit quote', String(r.quote ?? '')) ?? '';
+                              if (!nextQuote.trim()) return;
+                              const nextTagline = window.prompt('Edit tagline (optional)', String(r.tagline ?? '')) ?? '';
+                              const nextExpires = window.prompt('Edit expiresAt ISO (optional)', String(r.expiresAt ?? '')) ?? '';
+                              void curateReceipt({
+                                action: 'update',
+                                surface: 'pocket',
+                                receiptId: r.id,
+                                quote: nextQuote,
+                                tagline: nextTagline.trim() ? nextTagline.trim() : null,
+                                rating: typeof r.rating === 'number' ? r.rating : null,
+                                expiresAt: nextExpires.trim() ? nextExpires.trim() : null,
+                              });
+                            }}
+                            disabled={curateBusyId === r.id}
+                            style={{
+                              padding: '7px 10px',
+                              borderRadius: '8px',
+                              border: '1px solid var(--border)',
+                              background: 'transparent',
+                              color: 'var(--text)',
+                              cursor: 'pointer',
+                              fontWeight: 700,
+                            }}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => void curateReceipt({ action: 'unfeature', surface: 'pocket', receiptId: r.id })}
+                            disabled={curateBusyId === r.id}
+                            style={{
+                              padding: '7px 10px',
+                              borderRadius: '8px',
+                              border: '1px solid color-mix(in srgb, var(--danger) 55%, var(--border))',
+                              background: 'transparent',
+                              color: 'var(--danger)',
+                              cursor: 'pointer',
+                              fontWeight: 800,
+                            }}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                    {featuredPocket.length === 0 && (
+                      <div style={{ padding: '10px 14px', color: 'var(--text-secondary)' }}>No featured receipts.</div>
+                    )}
+                  </div>
+                </div>
+
+                <div style={{ border: '1px solid var(--border)', borderRadius: '10px', overflow: 'hidden' }}>
+                  <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--border)', fontWeight: 700 }}>
+                    Featured receipts — Open (public)
+                  </div>
+                  <div style={{ maxHeight: '220px', overflow: 'auto' }}>
+                    {featuredOpen.map((r) => (
+                      <div key={r.id} style={{ padding: '10px 14px', borderBottom: '1px solid var(--border)' }}>
+                        <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                          {r.tagline ?? '—'} {typeof r.rating === 'number' ? `· ${r.rating}/5` : ''}
+                        </div>
+                        <div style={{ marginTop: '6px', fontSize: '13px', whiteSpace: 'pre-wrap' }}>
+                          {String(r.quote ?? '').slice(0, 220)}
+                          {String(r.quote ?? '').length > 220 ? '…' : ''}
+                        </div>
+                        <div style={{ marginTop: '8px', display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                          <button
+                            onClick={() => {
+                              const nextQuote = window.prompt('Edit quote', String(r.quote ?? '')) ?? '';
+                              if (!nextQuote.trim()) return;
+                              const nextTagline = window.prompt('Edit tagline (optional)', String(r.tagline ?? '')) ?? '';
+                              const nextExpires = window.prompt('Edit expiresAt ISO (optional)', String(r.expiresAt ?? '')) ?? '';
+                              void curateReceipt({
+                                action: 'update',
+                                surface: 'open',
+                                receiptId: r.id,
+                                quote: nextQuote,
+                                tagline: nextTagline.trim() ? nextTagline.trim() : null,
+                                rating: typeof r.rating === 'number' ? r.rating : null,
+                                expiresAt: nextExpires.trim() ? nextExpires.trim() : null,
+                              });
+                            }}
+                            disabled={curateBusyId === r.id}
+                            style={{
+                              padding: '7px 10px',
+                              borderRadius: '8px',
+                              border: '1px solid var(--border)',
+                              background: 'transparent',
+                              color: 'var(--text)',
+                              cursor: 'pointer',
+                              fontWeight: 700,
+                            }}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => void curateReceipt({ action: 'unfeature', surface: 'open', receiptId: r.id })}
+                            disabled={curateBusyId === r.id}
+                            style={{
+                              padding: '7px 10px',
+                              borderRadius: '8px',
+                              border: '1px solid color-mix(in srgb, var(--danger) 55%, var(--border))',
+                              background: 'transparent',
+                              color: 'var(--danger)',
+                              cursor: 'pointer',
+                              fontWeight: 800,
+                            }}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                    {featuredOpen.length === 0 && (
+                      <div style={{ padding: '10px 14px', color: 'var(--text-secondary)' }}>No featured receipts.</div>
+                    )}
+                  </div>
+                </div>
+
+                <div style={{ border: '1px solid var(--border)', borderRadius: '10px', overflow: 'hidden' }}>
+                  <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--border)', fontWeight: 700 }}>
+                    P0 alert deliveries (latest)
+                  </div>
+                  <div style={{ maxHeight: '240px', overflow: 'auto' }}>
+                    {feedbackAlerts.slice(0, 80).map((a) => (
+                      <div key={a.id} style={{ padding: '10px 14px', borderBottom: '1px solid var(--border)' }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
+                          <div style={{ fontSize: '13px', fontWeight: 700 }}>
+                            {a.category ?? '—'} · {a.surface ?? '—'}
+                          </div>
+                          <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                            {a.createdAt ? new Date(a.createdAt).toLocaleString('en-GB') : '—'}
+                          </div>
+                        </div>
+                        <div style={{ marginTop: '6px', fontSize: '12px', color: 'var(--text-secondary)' }}>
+                          email: {a.email?.ok ? 'ok' : 'fail'} · webhook: {a.webhook?.ok ? 'ok' : 'fail'} · sub:{' '}
+                          <code>{String(a.submissionId ?? '').slice(0, 10)}…</code>
+                        </div>
+                      </div>
+                    ))}
+                    {feedbackAlerts.length === 0 && (
+                      <div style={{ padding: '10px 14px', color: 'var(--text-secondary)' }}>No alerts yet.</div>
+                    )}
+                  </div>
+                </div>
+              </div>
             </div>
           </section>
 

--- a/app/api/admin/feedback/alerts/route.ts
+++ b/app/api/admin/feedback/alerts/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
+import { initializeApp, getApps, cert } from 'firebase-admin/app';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      }),
+    });
+  }
+  return getFirestore();
+}
+
+async function requireAdmin(request: NextRequest): Promise<void> {
+  const authHeader = request.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token) throw Object.assign(new Error('Unauthorized'), { status: 401 });
+  const decoded = await getAuth().verifyIdToken(token);
+  const tokenEmail = (decoded as { email?: string }).email?.toLowerCase?.();
+  const adminAllowlist = (process.env.ADMIN_EMAIL_OVERRIDE ?? '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  const allowedByClaim = !!decoded.claims?.admin;
+  const allowedByEmail = tokenEmail && adminAllowlist.includes(tokenEmail);
+  if (!allowedByClaim && !allowedByEmail) {
+    throw Object.assign(new Error('Forbidden'), { status: 403, code: 'ADMIN_CLAIM_REQUIRED' });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin(request);
+    const db = getDb();
+    const limitParam = request.nextUrl.searchParams.get('limit');
+    const limit = Math.max(10, Math.min(500, Number.parseInt(String(limitParam ?? ''), 10) || 200));
+    const snap = await db.collection('feedbackAlertDeliveries').orderBy('createdAt', 'desc').limit(limit).get();
+    const alerts = snap.docs.map((doc) => {
+      const d = doc.data() as any;
+      return {
+        id: doc.id,
+        createdAt: d.createdAt?.toDate?.()?.toISOString?.() ?? null,
+        submissionId: d.submissionId ?? null,
+        surface: d.surface ?? null,
+        category: d.category ?? null,
+        anonUserHash: d.anonUserHash ?? null,
+        email: d.email ?? null,
+        webhook: d.webhook ?? null,
+      };
+    });
+    return NextResponse.json({ ok: true, alerts });
+  } catch (e: any) {
+    const status = typeof e?.status === 'number' ? e.status : 500;
+    if (status === 401) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (status === 403)
+      return NextResponse.json(
+        { error: 'Forbidden', code: e?.code ?? 'ADMIN_CLAIM_REQUIRED' },
+        { status: 403 }
+      );
+    console.error('[admin feedback alerts] error', e);
+    return NextResponse.json({ error: e?.message ?? 'Failed' }, { status: 500 });
+  }
+}
+

--- a/app/api/admin/feedback/curate/route.ts
+++ b/app/api/admin/feedback/curate/route.ts
@@ -1,0 +1,169 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
+import { initializeApp, getApps, cert } from 'firebase-admin/app';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      }),
+    });
+  }
+  return getFirestore();
+}
+
+async function requireAdmin(request: NextRequest): Promise<{ uid: string; email?: string }> {
+  const authHeader = request.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token) throw Object.assign(new Error('Unauthorized'), { status: 401 });
+  const decoded = await getAuth().verifyIdToken(token);
+  const tokenEmail = (decoded as { email?: string }).email?.toLowerCase?.();
+  const adminAllowlist = (process.env.ADMIN_EMAIL_OVERRIDE ?? '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  const allowedByClaim = !!decoded.claims?.admin;
+  const allowedByEmail = tokenEmail && adminAllowlist.includes(tokenEmail);
+  if (!allowedByClaim && !allowedByEmail) {
+    throw Object.assign(new Error('Forbidden'), { status: 403, code: 'ADMIN_CLAIM_REQUIRED' });
+  }
+  return { uid: decoded.uid, email: tokenEmail };
+}
+
+function clampStr(v: unknown, max: number): string {
+  return typeof v === 'string' ? v.trim().slice(0, max) : '';
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireAdmin(request);
+    const body = await request.json().catch(() => ({}));
+
+    const action = clampStr(body?.action, 32);
+    const surface = clampStr(body?.surface, 16);
+    const receiptId = clampStr(body?.receiptId, 120);
+
+    const db = getDb();
+
+    if (action === 'unfeature') {
+      if (!receiptId) return NextResponse.json({ error: 'receiptId required' }, { status: 400 });
+      const receiptRef = db.collection('featuredReceipts').doc(receiptId);
+      const receiptSnap = await receiptRef.get();
+      const receiptData = receiptSnap.data() as { sourceSubmissionId?: string; surface?: string } | undefined;
+      await receiptRef.delete();
+
+      const linkedSubmissionId = receiptData?.sourceSubmissionId;
+      const linkedSurface = receiptData?.surface;
+      if (linkedSubmissionId && (linkedSurface === 'pocket' || linkedSurface === 'open')) {
+        const subRef = db.collection('feedbackSubmissions').doc(linkedSubmissionId);
+        const subSnap = await subRef.get();
+        if (subSnap.exists) {
+          const sub = subSnap.data() as { featuredReceiptIds?: Record<string, string | null> } | undefined;
+          const featuredReceiptIds = { ...(sub?.featuredReceiptIds ?? {}) };
+          if (featuredReceiptIds[linkedSurface] === receiptId) {
+            featuredReceiptIds[linkedSurface] = null;
+          }
+          await subRef.set({ featuredReceiptIds, lastCuratedAt: Timestamp.now() }, { merge: true });
+        }
+      }
+
+      return NextResponse.json({ ok: true });
+    }
+
+    const quote = clampStr(body?.quote, 600);
+    const tagline = clampStr(body?.tagline, 120) || null;
+    const rating = typeof body?.rating === 'number' && Number.isFinite(body.rating) ? body.rating : null;
+    const expiresAtIso = clampStr(body?.expiresAt, 64) || null;
+    const submissionId = clampStr(body?.submissionId, 120) || null;
+
+    if (surface !== 'pocket' && surface !== 'open') {
+      return NextResponse.json({ error: 'surface must be pocket or open' }, { status: 400 });
+    }
+    if (!quote) return NextResponse.json({ error: 'quote required' }, { status: 400 });
+
+    const now = Timestamp.now();
+    const expiresAt = expiresAtIso ? Timestamp.fromDate(new Date(expiresAtIso)) : null;
+    if (expiresAtIso && Number.isNaN(expiresAt?.toDate?.().getTime?.() ?? NaN)) {
+      return NextResponse.json({ error: 'expiresAt must be ISO date string' }, { status: 400 });
+    }
+
+    if (action === 'create') {
+      if (submissionId) {
+        const subRef = db.collection('feedbackSubmissions').doc(submissionId);
+        const subSnap = await subRef.get();
+        if (subSnap.exists) {
+          const sub = subSnap.data() as { featuredReceiptIds?: Record<string, string | null> } | undefined;
+          const existingId = sub?.featuredReceiptIds?.[surface];
+          if (existingId) {
+            return NextResponse.json(
+              { error: `Submission already featured on ${surface}` },
+              { status: 409 }
+            );
+          }
+        }
+      }
+
+      const doc = await db.collection('featuredReceipts').add({
+        surface,
+        quote,
+        tagline,
+        rating,
+        featuredAt: now,
+        lastEditedAt: now,
+        expiresAt,
+        ...(submissionId ? { sourceSubmissionId: submissionId } : {}),
+      });
+
+      if (submissionId) {
+        const subRef = db.collection('feedbackSubmissions').doc(submissionId);
+        const subSnap = await subRef.get();
+        if (subSnap.exists) {
+          const sub = subSnap.data() as { featuredReceiptIds?: Record<string, string | null> } | undefined;
+          const featuredReceiptIds = { ...(sub?.featuredReceiptIds ?? {}) };
+          featuredReceiptIds[surface] = doc.id;
+          await subRef.set({ featuredReceiptIds, lastCuratedAt: now }, { merge: true });
+        }
+      }
+
+      return NextResponse.json({ ok: true, id: doc.id });
+    }
+
+    if (action === 'update') {
+      if (!receiptId) return NextResponse.json({ error: 'receiptId required' }, { status: 400 });
+      await db.collection('featuredReceipts').doc(receiptId).set(
+        {
+          surface,
+          quote,
+          tagline,
+          rating,
+          lastEditedAt: now,
+          expiresAt,
+        },
+        { merge: true }
+      );
+      return NextResponse.json({ ok: true, id: receiptId });
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+  } catch (e: any) {
+    const status = typeof e?.status === 'number' ? e.status : 500;
+    if (status === 401) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (status === 403)
+      return NextResponse.json(
+        { error: 'Forbidden', code: e?.code ?? 'ADMIN_CLAIM_REQUIRED' },
+        { status: 403 }
+      );
+    console.error('[admin feedback curate] error', e);
+    return NextResponse.json({ error: e?.message ?? 'Failed' }, { status: 500 });
+  }
+}
+

--- a/app/api/admin/feedback/submissions/route.ts
+++ b/app/api/admin/feedback/submissions/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
+import { initializeApp, getApps, cert } from 'firebase-admin/app';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      }),
+    });
+  }
+  return getFirestore();
+}
+
+async function requireAdmin(request: NextRequest): Promise<void> {
+  const authHeader = request.headers.get('authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token) throw Object.assign(new Error('Unauthorized'), { status: 401 });
+  const decoded = await getAuth().verifyIdToken(token);
+  const tokenEmail = (decoded as { email?: string }).email?.toLowerCase?.();
+  const adminAllowlist = (process.env.ADMIN_EMAIL_OVERRIDE ?? '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  const allowedByClaim = !!decoded.claims?.admin;
+  const allowedByEmail = tokenEmail && adminAllowlist.includes(tokenEmail);
+  if (!allowedByClaim && !allowedByEmail) {
+    throw Object.assign(new Error('Forbidden'), { status: 403, code: 'ADMIN_CLAIM_REQUIRED' });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin(request);
+    const db = getDb();
+    const limitParam = request.nextUrl.searchParams.get('limit');
+    const limit = Math.max(10, Math.min(500, Number.parseInt(String(limitParam ?? ''), 10) || 200));
+    const snap = await db.collection('feedbackSubmissions').orderBy('createdAt', 'desc').limit(limit).get();
+    let featuredBySubmission = new Map<string, { pocket: string | null; open: string | null }>();
+    try {
+      const featuredSnap = await db.collection('featuredReceipts').limit(200).get();
+      for (const doc of featuredSnap.docs) {
+        const data = doc.data() as { sourceSubmissionId?: string; surface?: string; quote?: string };
+        const submissionId = data.sourceSubmissionId;
+        const surface = data.surface;
+        if (!submissionId || (surface !== 'pocket' && surface !== 'open')) continue;
+        const entry = featuredBySubmission.get(submissionId) ?? { pocket: null, open: null };
+        entry[surface] = doc.id;
+        featuredBySubmission.set(submissionId, entry);
+      }
+      // Legacy receipts promoted before submission linking — match by quote prefix.
+      for (const doc of featuredSnap.docs) {
+        const data = doc.data() as { sourceSubmissionId?: string; surface?: string; quote?: string };
+        if (data.sourceSubmissionId) continue;
+        const surface = data.surface;
+        if (surface !== 'pocket' && surface !== 'open') continue;
+        const quoteKey = String(data.quote ?? '').slice(0, 120);
+        if (!quoteKey) continue;
+        for (const subDoc of snap.docs) {
+          const subComment = String(subDoc.data().commentScrubbed ?? '').slice(0, 120);
+          if (quoteKey !== subComment) continue;
+          const entry = featuredBySubmission.get(subDoc.id) ?? { pocket: null, open: null };
+          if (!entry[surface]) {
+            entry[surface] = doc.id;
+            featuredBySubmission.set(subDoc.id, entry);
+          }
+        }
+      }
+    } catch {
+      // featured index optional during bootstrap
+    }
+
+    const submissions = snap.docs.map((doc) => {
+      const d = doc.data() as any;
+      const storedIds = {
+        pocket: d.featuredReceiptIds?.pocket ?? null,
+        open: d.featuredReceiptIds?.open ?? null,
+      };
+      const linkedIds = featuredBySubmission.get(doc.id);
+      const featuredReceiptIds = {
+        pocket: storedIds.pocket ?? linkedIds?.pocket ?? null,
+        open: storedIds.open ?? linkedIds?.open ?? null,
+      };
+      return {
+        id: doc.id,
+        createdAt: d.createdAt?.toDate?.()?.toISOString?.() ?? null,
+        surface: d.surface ?? null,
+        rating: typeof d.rating === 'number' ? d.rating : null,
+        friction: d.friction ?? null,
+        category: d.category ?? null,
+        commentScrubbed: d.commentScrubbed ?? '',
+        anonUserHash: d.anonUserHash ?? null,
+        tierBand: d.tierBand ?? null,
+        dashboardVisitWindow: d.dashboardVisitWindow ?? null,
+        featuredReceiptIds,
+        lastCuratedAt: d.lastCuratedAt?.toDate?.()?.toISOString?.() ?? null,
+      };
+    });
+    return NextResponse.json({ ok: true, submissions });
+  } catch (e: any) {
+    const status = typeof e?.status === 'number' ? e.status : 500;
+    if (status === 401) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (status === 403)
+      return NextResponse.json(
+        { error: 'Forbidden', code: e?.code ?? 'ADMIN_CLAIM_REQUIRED' },
+        { status: 403 }
+      );
+    console.error('[admin feedback submissions] error', e);
+    return NextResponse.json({ error: e?.message ?? 'Failed' }, { status: 500 });
+  }
+}
+

--- a/app/api/feedback/featured/route.ts
+++ b/app/api/feedback/featured/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirestore } from 'firebase-admin/firestore';
+import { initializeApp, getApps, cert } from 'firebase-admin/app';
+import type { FeedbackSurface } from '@/app/lib/feedback/types';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      }),
+    });
+  }
+  return getFirestore();
+}
+
+function isSurface(v: string | null): v is FeedbackSurface {
+  return v === 'pocket' || v === 'open';
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const surfaceParam = request.nextUrl.searchParams.get('surface');
+    const surface: FeedbackSurface = isSurface(surfaceParam) ? surfaceParam : 'pocket';
+
+    const db = getDb();
+    let snap;
+    try {
+      snap = await db.collection('featuredReceipts').orderBy('featuredAt', 'desc').limit(120).get();
+    } catch {
+      // Collection empty or index not yet provisioned — unfiltered read still works.
+      snap = await db.collection('featuredReceipts').limit(120).get();
+    }
+
+    const receipts = snap.docs
+      .map((d) => {
+      const data = d.data() as any;
+        return {
+          id: d.id,
+          surface: data.surface,
+          quote: data.quote,
+          rating: typeof data.rating === 'number' ? data.rating : null,
+          tagline: typeof data.tagline === 'string' ? data.tagline : null,
+          featuredAt: data.featuredAt?.toDate?.()?.toISOString?.() ?? null,
+          lastEditedAt: data.lastEditedAt?.toDate?.()?.toISOString?.() ?? null,
+          expiresAt: data.expiresAt?.toDate?.()?.toISOString?.() ?? null,
+        };
+      })
+      .filter((r) => r.surface === surface)
+      .sort((a, b) => {
+        const ta = a.featuredAt ? Date.parse(a.featuredAt) : 0;
+        const tb = b.featuredAt ? Date.parse(b.featuredAt) : 0;
+        return tb - ta;
+      })
+      .slice(0, 24);
+
+    // Filter expired on the server (so public clients never see stale receipts).
+    const now = Date.now();
+    const fresh = receipts.filter((r) => {
+      if (!r.expiresAt) return true;
+      const t = Date.parse(r.expiresAt);
+      return Number.isFinite(t) ? t > now : true;
+    });
+
+    return NextResponse.json({ ok: true, surface, receipts: fresh });
+  } catch (e: any) {
+    console.error('[feedback featured] error', e);
+    return NextResponse.json({ ok: false, error: e?.message ?? 'Failed' }, { status: 500 });
+  }
+}
+

--- a/app/api/feedback/submit/route.ts
+++ b/app/api/feedback/submit/route.ts
@@ -1,0 +1,274 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
+import { initializeApp, getApps, cert } from 'firebase-admin/app';
+import { createHash, createHmac } from 'crypto';
+import { scrubFeedbackText } from '@/app/lib/feedback/scrub';
+import type {
+  FeedbackCategory,
+  FeedbackFriction,
+  FeedbackSeverityClass,
+  FeedbackSurface,
+  FeedbackTierBand,
+} from '@/app/lib/feedback/types';
+import { checkKvRateLimit } from '@/app/lib/server/kv-rate-limit';
+import { sendFeedbackP0AlertEmail } from '@/lib/stack-reveal/resend';
+import { getEffectivePaidTier } from '@/app/lib/tier/effectivePaid';
+import { resolvePaidTierFromStripeEmail } from '@/app/lib/server/stripe-paid-tier';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+function getDb() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      }),
+    });
+  }
+  return getFirestore();
+}
+
+function clampInt(n: unknown, min: number, max: number, fallback: number): number {
+  const v = typeof n === 'number' ? n : Number.parseInt(String(n ?? ''), 10);
+  if (!Number.isFinite(v)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(v)));
+}
+
+function isValidFriction(v: unknown): v is FeedbackFriction {
+  return v === 'frictionless' || v === 'broken';
+}
+
+function isValidSurface(v: unknown): v is FeedbackSurface {
+  return v === 'pocket' || v === 'open';
+}
+
+function inferSeverity(params: {
+  rating: number;
+  friction: FeedbackFriction;
+  category: FeedbackCategory;
+  comment: string;
+}): FeedbackSeverityClass {
+  const breakCats = new Set<FeedbackCategory>([
+    'break_parser_failure',
+    'break_context_missed_data',
+    'break_quotes_or_market_data',
+    'break_auth_or_sync',
+  ]);
+  if (params.friction === 'broken') return 'P0';
+  if (params.rating <= 2 && breakCats.has(params.category)) return 'P0';
+  // Lexical safety net. Intentionally small & non-exhaustive.
+  const t = params.comment.toLowerCase();
+  const parserLex = ['parser failed', 'import failed', 'column mapping', 'unknown column', 'invalid header', 'csv failed'];
+  if (breakCats.has(params.category) && parserLex.some((p) => t.includes(p))) return 'P0';
+  if (params.rating <= 3 && breakCats.has(params.category)) return 'P1';
+  return 'P2';
+}
+
+function anonUserHashFromUid(uid: string): string {
+  const pepper =
+    process.env.FEEDBACK_ANON_PEPPER?.trim() ||
+    process.env.ENCRYPTION_SECRET?.trim() ||
+    '';
+  if (pepper.length >= 16) {
+    return createHmac('sha256', pepper).update(uid).digest('hex').slice(0, 48);
+  }
+  return createHash('sha256').update(uid).digest('hex').slice(0, 48);
+}
+
+function tierBandFromTier(tier: string | null | undefined): FeedbackTierBand {
+  if (tier === 'foundersClub') return 'foundersClub';
+  if (tier === 'corporateSponsor') return 'corporateSponsor';
+  if (tier == null) return 'free';
+  return 'unknown';
+}
+
+function escapeHtml(s: string): string {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+async function postWebhook(url: string, payload: unknown): Promise<{ ok: boolean; status?: number; error?: string }> {
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      cache: 'no-store',
+    });
+    if (!res.ok) return { ok: false, status: res.status, error: `webhook_non_2xx_${res.status}` };
+    return { ok: true, status: res.status };
+  } catch (e: any) {
+    return { ok: false, error: e?.message ?? 'webhook_failed' };
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const decoded = await getAuth().verifyIdToken(token);
+    const uid = decoded.uid;
+    const email = (decoded as { email?: string }).email ?? null;
+
+    const body = await request.json().catch(() => ({}));
+    const surfaceRaw = body?.surface;
+    const surface: FeedbackSurface = isValidSurface(surfaceRaw) ? surfaceRaw : 'pocket';
+
+    const rating = clampInt(body?.rating, 1, 5, 5);
+    const friction: FeedbackFriction = isValidFriction(body?.friction) ? body.friction : 'frictionless';
+    const category = typeof body?.category === 'string' ? (body.category as FeedbackCategory) : 'other';
+    const commentRaw = typeof body?.comment === 'string' ? body.comment : '';
+    const dashboardVisitCount =
+      typeof body?.dashboardVisitCount === 'number' && Number.isFinite(body.dashboardVisitCount)
+        ? Math.max(0, Math.trunc(body.dashboardVisitCount))
+        : null;
+
+    if (!commentRaw.trim()) {
+      return NextResponse.json({ error: 'comment is required' }, { status: 400 });
+    }
+
+    const scrubbed = scrubFeedbackText(commentRaw, { maxChars: 4000 });
+    const severityClass = inferSeverity({
+      rating,
+      friction,
+      category,
+      comment: scrubbed.text,
+    });
+
+    let tier: string | null = null;
+    try {
+      if (email) {
+        const paid = await resolvePaidTierFromStripeEmail(email);
+        const effective = getEffectivePaidTier(paid);
+        tier = effective.tier;
+      }
+    } catch {
+      // tier resolution is best-effort
+    }
+    const tierBand = tierBandFromTier(tier);
+
+    const anonUserHash = anonUserHashFromUid(uid);
+    const db = getDb();
+    const createdAt = Timestamp.now();
+
+    const submissionDoc = await db.collection('feedbackSubmissions').add({
+      createdAt,
+      surface,
+      rating,
+      friction,
+      category,
+      commentScrubbed: scrubbed.text,
+      commentScrubMeta: scrubbed.meta,
+      anonUserHash,
+      tierBand,
+      dashboardVisitWindow: dashboardVisitCount == null ? null : { windowDays: 7, count: dashboardVisitCount },
+      appVersion: request.headers.get('x-app-version') || null,
+    });
+
+    // Dedup gate for P0 alerts: allow 1 per (anonHash, category) per 24h
+    let dedupedAlert = false;
+    if (severityClass === 'P0') {
+      const rl = await checkKvRateLimit(
+        'feedback:p0',
+        `${anonUserHash}:${category}`,
+        1,
+        24 * 60 * 60
+      );
+      dedupedAlert = !rl.allowed;
+    }
+
+    await db.collection('feedbackEvents').add({
+      createdAt,
+      surface,
+      rating,
+      friction,
+      category,
+      severityClass,
+      tierBand,
+      dedupedAlert,
+    });
+
+    if (severityClass === 'P0' && !dedupedAlert) {
+      const inbox = (process.env.FEEDBACK_ENGINEERING_EMAIL ?? 'ai@pocketportfolio.app')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const subject = `[P0 Feedback] ${category} · rating ${rating}/5 · ${friction}`;
+      const excerpt = scrubbed.text.slice(0, 380);
+      const html = `
+        <p><strong>Severity:</strong> P0</p>
+        <p><strong>Surface:</strong> ${escapeHtml(surface)}</p>
+        <p><strong>Category:</strong> ${escapeHtml(category)}</p>
+        <p><strong>Rating:</strong> ${rating}/5</p>
+        <p><strong>Outcome:</strong> ${escapeHtml(friction)}</p>
+        <p><strong>Tier band:</strong> ${escapeHtml(tierBand)}</p>
+        <p><strong>Anon hash:</strong> <code>${escapeHtml(anonUserHash)}</code></p>
+        <p><strong>Submission:</strong> <code>${escapeHtml(submissionDoc.id)}</code></p>
+        <hr/>
+        <pre style="white-space:pre-wrap;font-family:ui-monospace,Menlo,Consolas,monospace;">${escapeHtml(excerpt)}</pre>
+        <p style="margin-top:14px;color:#6b7280;font-size:12px;">Scrubbed excerpt only. Full triage in admin.</p>
+      `;
+
+      const deliveryRef = db.collection('feedbackAlertDeliveries').doc();
+      const webhookUrl = process.env.FEEDBACK_P0_WEBHOOK_URL?.trim() || '';
+
+      const emailResult = await sendFeedbackP0AlertEmail({
+        to: inbox,
+        subject,
+        html,
+        replyTo: email ?? undefined,
+      });
+
+      const webhookResult = webhookUrl
+        ? await postWebhook(webhookUrl, {
+            kind: 'feedback_p0',
+            surface,
+            category,
+            rating,
+            friction,
+            tierBand,
+            anonUserHash,
+            submissionId: submissionDoc.id,
+            createdAt: new Date().toISOString(),
+            excerpt,
+          })
+        : { ok: false, error: 'webhook_not_configured' };
+
+      await deliveryRef.set({
+        createdAt,
+        submissionId: submissionDoc.id,
+        surface,
+        category,
+        anonUserHash,
+        email: {
+          to: inbox,
+          ok: !emailResult.error,
+          id: emailResult.id ?? null,
+          error: emailResult.error ?? null,
+        },
+        webhook: {
+          ok: webhookResult.ok,
+          status: webhookResult.status ?? null,
+          error: webhookResult.error ?? null,
+        },
+      });
+    }
+
+    return NextResponse.json({ ok: true, id: submissionDoc.id, severityClass, dedupedAlert });
+  } catch (e: any) {
+    console.error('[feedback submit] error', e);
+    return NextResponse.json({ error: e?.message ?? 'Failed to submit feedback' }, { status: 500 });
+  }
+}
+

--- a/app/components/feedback/FeedbackModal.tsx
+++ b/app/components/feedback/FeedbackModal.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import type { User } from 'firebase/auth';
+import { FEEDBACK_TEMPLATES } from '@/app/lib/feedback/templates';
+import type {
+  FeedbackCategory,
+  FeedbackFriction,
+  FeedbackSurface,
+  FeedbackSubmissionDraft,
+} from '@/app/lib/feedback/types';
+import { scrubFeedbackText } from '@/app/lib/feedback/scrub';
+import { SentimentScale } from './SentimentScale';
+
+const MONO: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, Consolas, monospace',
+};
+
+function kindLabel(kind: 'signal' | 'friction' | 'break'): string {
+  if (kind === 'signal') return 'Signal';
+  if (kind === 'friction') return 'Friction';
+  return 'Break';
+}
+
+export function FeedbackModal(props: {
+  open: boolean;
+  onClose: () => void;
+  user: User;
+  surface?: FeedbackSurface;
+  dashboardVisitCount?: number;
+}) {
+  const { open, onClose, user } = props;
+  const surface: FeedbackSurface = props.surface ?? 'pocket';
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const [rating, setRating] = useState<number>(5);
+  const [friction, setFriction] = useState<FeedbackFriction>('frictionless');
+  const [category, setCategory] = useState<FeedbackCategory>('signal_local_first_speed');
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const templateGroups = useMemo(() => {
+    const groups: Record<'signal' | 'friction' | 'break', typeof FEEDBACK_TEMPLATES> = {
+      signal: [],
+      friction: [],
+      break: [],
+    };
+    for (const t of FEEDBACK_TEMPLATES) groups[t.kind].push(t);
+    return groups;
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  const reset = () => {
+    setRating(5);
+    setFriction('frictionless');
+    setCategory('signal_local_first_speed');
+    setComment('');
+    setError(null);
+    setSubmitting(false);
+    setSuccess(false);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const applyTemplate = (id: FeedbackCategory, draft: string) => {
+    setCategory(id);
+    setComment((prev) => (prev?.trim().length ? prev : draft));
+    if (id.startsWith('break_')) {
+      setFriction('broken');
+      setRating((r) => Math.min(r, 2));
+    } else if (id.startsWith('friction_')) {
+      setFriction('frictionless');
+      setRating((r) => Math.min(r, 4));
+    }
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) onClose();
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!Number.isFinite(rating) || rating < 1 || rating > 5) {
+      setError('Rating must be between 1 and 5.');
+      return;
+    }
+    if (!comment.trim()) {
+      setError('Please add a short comment (scrubbed before submit).');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const token = await user.getIdToken(true);
+      const scrubbed = scrubFeedbackText(comment, { maxChars: 4000 });
+      const payload: FeedbackSubmissionDraft & {
+        commentScrubMeta: unknown;
+        dashboardVisitCount?: number;
+      } = {
+        surface,
+        rating,
+        friction,
+        category,
+        comment: scrubbed.text,
+        commentScrubMeta: scrubbed.meta,
+        dashboardVisitCount: props.dashboardVisitCount,
+      };
+
+      const res = await fetch('/api/feedback/submit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(typeof data?.error === 'string' ? data.error : `Request failed (${res.status})`);
+      }
+      setSuccess(true);
+      setTimeout(() => {
+        onClose();
+      }, 1100);
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to submit feedback');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) return null;
+  if (typeof document === 'undefined' || !document.body) return null;
+
+  return createPortal(
+    <div
+      ref={overlayRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="feedback-modal-title"
+      onClick={handleOverlayClick}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 10000,
+        background: 'rgba(0,0,0,0.62)',
+        backdropFilter: 'blur(6px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '18px',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 'min(860px, 100%)',
+          maxHeight: '90vh',
+          overflow: 'auto',
+          borderRadius: '14px',
+          background: 'var(--surface)',
+          border: '1px solid var(--border-subtle)',
+          boxShadow: '0 22px 60px rgba(0,0,0,0.35)',
+        }}
+      >
+        <div
+          style={{
+            padding: '18px 18px 14px',
+            borderBottom: '1px solid var(--border-subtle)',
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: '12px',
+          }}
+        >
+          <div style={{ display: 'grid', gap: '6px' }}>
+            <div id="feedback-modal-title" style={{ fontSize: '16px', fontWeight: 800, ...MONO }}>
+              Feedback — adversarial harness signal
+            </div>
+            <div style={{ fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.4 }}>
+              This is routed into the admin curation queue. Your comment is scrubbed for PII before leaving the browser.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              border: '1px solid var(--border-subtle)',
+              background: 'transparent',
+              color: 'var(--text-secondary)',
+              borderRadius: '10px',
+              padding: '8px',
+              cursor: 'pointer',
+            }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={onSubmit} style={{ padding: '16px 18px 18px', display: 'grid', gap: '16px' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '14px' }}>
+            <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '12px', padding: '14px', background: 'color-mix(in srgb, var(--surface) 85%, black)' }}>
+              <SentimentScale
+                rating={rating}
+                onRatingChange={setRating}
+                friction={friction}
+                onFrictionChange={setFriction}
+              />
+            </div>
+
+            <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '12px', padding: '14px', background: 'color-mix(in srgb, var(--surface) 85%, black)' }}>
+              <div style={{ fontSize: '12px', letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-secondary)', marginBottom: '10px', ...MONO }}>
+                Suggested templates (balanced)
+              </div>
+
+              {(['signal', 'friction', 'break'] as const).map((k) => (
+                <div key={k} style={{ marginBottom: '10px' }}>
+                  <div style={{ fontSize: '12px', fontWeight: 750, marginBottom: '6px', color: k === 'break' ? 'var(--danger)' : 'var(--text)', ...MONO }}>
+                    {kindLabel(k)}
+                  </div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                    {templateGroups[k].map((t) => {
+                      const active = category === t.id;
+                      return (
+                        <button
+                          key={t.id}
+                          type="button"
+                          onClick={() => applyTemplate(t.id, t.draft)}
+                          aria-pressed={active}
+                          style={{
+                            padding: '8px 10px',
+                            borderRadius: '999px',
+                            border: `1px solid ${active ? 'var(--accent-warm)' : 'var(--border-subtle)'}`,
+                            background: active
+                              ? 'color-mix(in srgb, var(--accent-warm) 16%, var(--surface))'
+                              : 'var(--surface)',
+                            color: 'var(--text)',
+                            cursor: 'pointer',
+                            fontSize: '12px',
+                            fontWeight: 650,
+                            ...MONO,
+                          }}
+                        >
+                          {t.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '12px', padding: '14px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '10px' }}>
+              <div style={{ fontSize: '12px', letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-secondary)', ...MONO }}>
+                Comment (PII-scrubbed)
+              </div>
+              {typeof props.dashboardVisitCount === 'number' && (
+                <div style={{ fontSize: '12px', color: 'var(--text-secondary)', ...MONO }}>
+                  dashboard visits (7d): {props.dashboardVisitCount}
+                </div>
+              )}
+            </div>
+            <textarea
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              rows={5}
+              placeholder="What broke? What did you expect? What dataset/export triggered it?"
+              style={{
+                marginTop: '10px',
+                width: '100%',
+                borderRadius: '12px',
+                border: '1px solid var(--border-subtle)',
+                background: 'var(--background)',
+                color: 'var(--text)',
+                padding: '12px',
+                fontSize: '13px',
+                lineHeight: 1.5,
+                resize: 'vertical',
+                ...MONO,
+              }}
+            />
+            <div style={{ marginTop: '8px', fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.4 }}>
+              Tip: avoid pasting raw exports. If you do, we redact ledger-like rows and identifier shapes.
+            </div>
+          </div>
+
+          {error && (
+            <div style={{ fontSize: '13px', color: 'var(--danger)', ...MONO }}>
+              {error}
+            </div>
+          )}
+          {success && (
+            <div style={{ fontSize: '13px', color: 'var(--signal)', ...MONO }}>
+              Submitted. Thank you — routed to engineering + CMS queue.
+            </div>
+          )}
+
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                padding: '10px 14px',
+                borderRadius: '10px',
+                border: '1px solid var(--border-subtle)',
+                background: 'transparent',
+                color: 'var(--text)',
+                cursor: 'pointer',
+                fontWeight: 650,
+                ...MONO,
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              style={{
+                padding: '10px 14px',
+                borderRadius: '10px',
+                border: '1px solid var(--accent-warm)',
+                background: 'var(--accent-warm)',
+                color: '#0f1216',
+                cursor: submitting ? 'not-allowed' : 'pointer',
+                fontWeight: 800,
+                opacity: submitting ? 0.75 : 1,
+                ...MONO,
+              }}
+            >
+              {submitting ? 'Submitting…' : 'Submit feedback'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
+}
+

--- a/app/components/feedback/SentimentScale.tsx
+++ b/app/components/feedback/SentimentScale.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React from 'react';
+import type { FeedbackFriction } from '@/app/lib/feedback/types';
+
+const MONO: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, Consolas, monospace',
+};
+
+export function SentimentScale(props: {
+  rating: number;
+  onRatingChange: (rating: number) => void;
+  friction: FeedbackFriction;
+  onFrictionChange: (friction: FeedbackFriction) => void;
+}) {
+  const { rating, onRatingChange, friction, onFrictionChange } = props;
+  const buttons = [1, 2, 3, 4, 5] as const;
+
+  return (
+    <div style={{ display: 'grid', gap: '10px' }}>
+      <div style={{ display: 'grid', gap: '6px' }}>
+        <div style={{ fontSize: '12px', letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-secondary)', ...MONO }}>
+          Rating (1–5)
+        </div>
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          {buttons.map((n) => {
+            const active = rating === n;
+            return (
+              <button
+                key={n}
+                type="button"
+                onClick={() => onRatingChange(n)}
+                aria-pressed={active}
+                style={{
+                  width: '40px',
+                  height: '40px',
+                  borderRadius: '10px',
+                  border: `1px solid ${active ? 'var(--accent-warm)' : 'var(--border-subtle)'}`,
+                  background: active ? 'color-mix(in srgb, var(--accent-warm) 18%, var(--surface))' : 'var(--surface)',
+                  color: 'var(--text)',
+                  cursor: 'pointer',
+                  fontWeight: 700,
+                  ...MONO,
+                }}
+              >
+                {n}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gap: '6px' }}>
+        <div style={{ fontSize: '12px', letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-secondary)', ...MONO }}>
+          Outcome
+        </div>
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          {(['frictionless', 'broken'] as const).map((v) => {
+            const active = friction === v;
+            return (
+              <button
+                key={v}
+                type="button"
+                onClick={() => onFrictionChange(v)}
+                aria-pressed={active}
+                style={{
+                  padding: '10px 12px',
+                  borderRadius: '10px',
+                  border: `1px solid ${active ? 'var(--accent-warm)' : 'var(--border-subtle)'}`,
+                  background: active ? 'color-mix(in srgb, var(--accent-warm) 18%, var(--surface))' : 'var(--surface)',
+                  color: 'var(--text)',
+                  cursor: 'pointer',
+                  fontWeight: 650,
+                  ...MONO,
+                }}
+              >
+                {v === 'frictionless' ? 'Frictionless' : 'Broken'}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/app/components/landing/RetailTrustSection.tsx
+++ b/app/components/landing/RetailTrustSection.tsx
@@ -14,7 +14,7 @@ export default function RetailTrustSection() {
         background: 'linear-gradient(135deg, var(--surface) 0%, var(--warm-bg) 100%)',
         borderTop: '1px solid var(--border-warm)',
         borderBottom: '1px solid var(--border-warm)',
-        marginBottom: 'clamp(60px, 10vw, 120px)',
+        marginBottom: 'clamp(32px, 6vw, 56px)',
       }}
     >
       <div style={{ maxWidth: '1200px', margin: '0 auto', textAlign: 'center' }}>

--- a/app/components/landing/VerifiedReceiptsSection.tsx
+++ b/app/components/landing/VerifiedReceiptsSection.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import type { FeedbackSurface } from '@/app/lib/feedback/types';
+
+type FeaturedReceipt = {
+  id: string;
+  surface: FeedbackSurface;
+  quote: string;
+  rating: number | null;
+  tagline: string | null;
+  featuredAt: string | null;
+  lastEditedAt: string | null;
+  expiresAt: string | null;
+};
+
+const MONO: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, Consolas, monospace',
+};
+
+export function VerifiedReceiptsSection(props: { surface: FeedbackSurface; title?: string; subtitle?: string }) {
+  const { surface } = props;
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [receipts, setReceipts] = useState<FeaturedReceipt[]>([]);
+
+  const copy = useMemo(() => {
+    if (surface === 'open') {
+      return {
+        title: props.title ?? 'Verified receipts',
+        subtitle:
+          props.subtitle ??
+          'Curated operator feedback from the live harness — published deliberately (no raw submissions).',
+      };
+    }
+    return {
+      title: props.title ?? 'Verified receipts',
+      subtitle:
+        props.subtitle ??
+        'Curated feedback from high-frequency dashboard users — published deliberately (no raw submissions).',
+    };
+  }, [props.subtitle, props.title, surface]);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetch(`/api/feedback/featured?surface=${surface}&_=${Date.now()}`, { cache: 'no-store' })
+      .then((res) => res.json().then((j) => ({ ok: res.ok, j })))
+      .then(({ ok, j }) => {
+        if (!ok) throw new Error(j?.error ?? 'Failed to load receipts');
+        const list = Array.isArray(j?.receipts) ? (j.receipts as FeaturedReceipt[]) : [];
+        setReceipts(list.slice(0, 12));
+      })
+      .catch((e: any) => setError(e?.message ?? 'Failed to load receipts'))
+      .finally(() => setLoading(false));
+  }, [surface]);
+
+  const isSingle = receipts.length === 1;
+
+  const sectionShellStyle: React.CSSProperties = {
+    margin: '0 auto clamp(48px, 8vw, 96px)',
+    maxWidth: '1200px',
+    padding: '0 clamp(12px, 3vw, 24px)',
+  };
+
+  const panelStyle: React.CSSProperties = {
+    border: '1px solid var(--border-subtle)',
+    borderRadius: '14px',
+    background: 'var(--surface)',
+    padding: 'clamp(24px, 4vw, 32px)',
+    borderLeft: '3px solid var(--accent-warm)',
+  };
+
+  if (loading) {
+    return (
+      <section style={sectionShellStyle}>
+        <div style={panelStyle}>
+          <div style={{ ...MONO, fontWeight: 900, fontSize: '18px' }}>{copy.title}</div>
+          <div style={{ marginTop: '8px', color: 'var(--text-secondary)', fontSize: '14px' }}>{copy.subtitle}</div>
+          <div style={{ marginTop: '18px', color: 'var(--text-secondary)', fontSize: '13px', ...MONO }}>
+            Loading receipts…
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (error || receipts.length === 0) {
+    return null;
+  }
+
+  return (
+    <section style={sectionShellStyle}>
+      <div style={panelStyle}>
+        <div
+          style={{
+            display: 'grid',
+            gap: '8px',
+            marginBottom: '20px',
+            textAlign: isSingle ? 'center' : 'left',
+            maxWidth: isSingle ? '640px' : 'none',
+            marginInline: isSingle ? 'auto' : undefined,
+          }}
+        >
+          <div style={{ ...MONO, fontWeight: 900, fontSize: '18px' }}>{copy.title}</div>
+          <div style={{ color: 'var(--text-secondary)', fontSize: '14px', lineHeight: 1.5 }}>{copy.subtitle}</div>
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: isSingle
+              ? 'minmax(0, 1fr)'
+              : 'repeat(auto-fit, minmax(280px, 1fr))',
+            gap: '16px',
+            justifyItems: isSingle ? 'center' : 'stretch',
+            alignItems: 'start',
+          }}
+        >
+          {receipts.map((r) => (
+            <div
+              key={r.id}
+              style={{
+                border: '1px solid var(--border-subtle)',
+                borderRadius: '12px',
+                background: 'color-mix(in srgb, var(--surface) 88%, black)',
+                padding: '16px',
+                width: '100%',
+                maxWidth: isSingle ? '560px' : undefined,
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px' }}>
+                <div style={{ fontSize: '12px', color: 'var(--text-secondary)', ...MONO }}>
+                  {r.tagline ?? (surface === 'open' ? 'infrastructure' : 'dashboard')}
+                </div>
+                {typeof r.rating === 'number' && (
+                  <div style={{ fontSize: '12px', color: 'var(--text-secondary)', ...MONO }}>
+                    {r.rating}/5
+                  </div>
+                )}
+              </div>
+              <div style={{ marginTop: '10px', fontSize: '13px', lineHeight: 1.55, whiteSpace: 'pre-wrap' }}>
+                “{r.quote}”
+              </div>
+              <div style={{ marginTop: '12px', fontSize: '11px', color: 'var(--text-tertiary)', ...MONO }}>
+                Verified receipt · curated
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {!isSingle && receipts.length > 1 && (
+          <p
+            style={{
+              marginTop: '16px',
+              fontSize: '12px',
+              color: 'var(--text-tertiary)',
+              textAlign: 'center',
+              ...MONO,
+            }}
+          >
+            {receipts.length} verified receipts · curated for {surface === 'open' ? 'Open' : 'Pocket'}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -73,6 +73,13 @@ import {
 import { Trade } from '../services/tradeService';
 import { buildPortfolioContext } from '../lib/ai/contextBuilder';
 import { usePocketAnalyst } from '../components/ai/PocketAnalystProvider';
+import { FeedbackModal } from '@/app/components/feedback/FeedbackModal';
+import {
+  recordDashboardVisit,
+  snoozeFeedbackPrompt,
+  shouldPromptForFeedback,
+} from '@/app/lib/feedback/eligibility';
+import { isFeedbackDevForceEmail } from '@/app/lib/feedback/devForce';
 
 // Extend Window interface for portfolio summary logging
 declare global {
@@ -322,6 +329,9 @@ export default function Dashboard() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [showFeatureAnnouncement, setShowFeatureAnnouncement] = useState(false);
   const modalScheduledRef = useRef(false); // Persist across re-renders
+  const [showFeedbackModal, setShowFeedbackModal] = useState(false);
+  const [feedbackDashboardVisitCount, setFeedbackDashboardVisitCount] = useState<number | null>(null);
+  const feedbackScheduledRef = useRef(false);
   const [showImportModal, setShowImportModal] = useState(false);
   const [showPostImportUpsell, setShowPostImportUpsell] = useState(false);
   const [importModalFile, setImportModalFile] = useState<File | null>(null);
@@ -359,6 +369,69 @@ export default function Dashboard() {
       }
     }
   }, [showDeleteModal, showAlertModal, alertModalData, isDeleting]);
+
+  // Feedback eligibility: count dashboard visits locally (no server tracing).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    recordDashboardVisit();
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!user || !isAuthenticated) return;
+
+    // Allow forcing via URL parameter for testing.
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('showFeedbackModal') === 'true') {
+      setFeedbackDashboardVisitCount(null);
+      setShowFeedbackModal(true);
+      return;
+    }
+
+    // Local dev: force prompt for configured test accounts (see NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS).
+    if (isFeedbackDevForceEmail(user.email)) {
+      setFeedbackDashboardVisitCount(5);
+      if (!feedbackScheduledRef.current) {
+        feedbackScheduledRef.current = true;
+        const t = setTimeout(() => setShowFeedbackModal(true), 500);
+        return () => clearTimeout(t);
+      }
+      return;
+    }
+
+    if (feedbackScheduledRef.current) return;
+
+    // Don't compete with onboarding or feature announcement.
+    const hasSeenTour = localStorage.getItem('pocket_onboarding_v2_seen') === 'true';
+    const hasSeenAnnouncement = Boolean(localStorage.getItem('pocket-portfolio-feature-announcement-seen'));
+    if (!hasSeenTour) return;
+    if (!hasSeenAnnouncement) return;
+    if (showFeatureAnnouncement) return;
+
+    // Don't show while other blocking modals are open.
+    if (showImportModal) return;
+    if (showDeleteModal || showAlertModal) return;
+
+    const elig = shouldPromptForFeedback({
+      isAuthenticated: true,
+      surface: 'pocket',
+      minDashboardVisitsInWindow: 5,
+      windowDays: 7,
+    });
+    setFeedbackDashboardVisitCount(elig.visitCount);
+    if (!elig.eligible) return;
+
+    feedbackScheduledRef.current = true;
+    const t = setTimeout(() => setShowFeedbackModal(true), 900);
+    return () => clearTimeout(t);
+  }, [
+    user,
+    isAuthenticated,
+    showFeatureAnnouncement,
+    showImportModal,
+    showDeleteModal,
+    showAlertModal,
+  ]);
 
   // Portfolio store integration
   const {
@@ -3360,6 +3433,21 @@ export default function Dashboard() {
         isOpen={showFeatureAnnouncement}
         onClose={handleCloseAnnouncement}
       />
+
+      {/* Feedback Modal (power-user trigger; write-path P0 router) */}
+      {user && (
+        <FeedbackModal
+          open={showFeedbackModal}
+          onClose={() => {
+            // Default posture: snooze for 7 days when user closes without submitting.
+            snoozeFeedbackPrompt(7);
+            setShowFeedbackModal(false);
+          }}
+          user={user}
+          surface="pocket"
+          dashboardVisitCount={feedbackDashboardVisitCount ?? undefined}
+        />
+      )}
 
       {/* Weekly Portfolio Snapshot toast (7-day return, local-only P&L) */}
       <WeeklySnapshotToast

--- a/app/landing/ControlLandingPage.tsx
+++ b/app/landing/ControlLandingPage.tsx
@@ -8,6 +8,7 @@ import { createPortal } from 'react-dom';
 import Logo from '../components/Logo';
 import ThemeSwitcher from '../components/ThemeSwitcher';
 import CommunityContent from '../components/CommunityContent';
+import { VerifiedReceiptsSection } from '../components/landing/VerifiedReceiptsSection';
 import SocialShare from '../components/viral/SocialShare';
 import FunnelTracker from '../components/analytics/FunnelTracker';
 import { LocalProcessingTerminal } from '../components/LocalProcessingTerminal';
@@ -2316,6 +2317,8 @@ $ npx pocket-init --sovereign
 
       {/* News Room — institutional briefings (static local-first grid) */}
       <CommunityContent />
+
+      <VerifiedReceiptsSection surface="pocket" />
 
       {/* Share Section */}
       <section style={{ 

--- a/app/landing/RetailLandingPage.tsx
+++ b/app/landing/RetailLandingPage.tsx
@@ -8,6 +8,7 @@ import LandingProductionNavbar from '../components/marketing/RetailProductionNav
 import RetailLandingHero from '../components/landing/RetailLandingHero';
 import { AnalystVideo } from '../components/landing/AnalystVideo';
 import RetailTrustSection from '../components/landing/RetailTrustSection';
+import { VerifiedReceiptsSection } from '../components/landing/VerifiedReceiptsSection';
 import ProductPortalSection from '../components/pocket-landing/ProductPortalSection';
 import RetailLandingFaq from '../components/landing/RetailLandingFaq';
 import { useAuth } from '../hooks/useAuth';
@@ -69,6 +70,8 @@ export default function RetailLandingPage() {
       </div>
 
       <RetailTrustSection />
+
+      <VerifiedReceiptsSection surface="pocket" />
 
       <main className="brand-surface brand-grid mobile-container">
         <ProductPortalSection variant="retail" />

--- a/app/lib/feedback/devForce.ts
+++ b/app/lib/feedback/devForce.ts
@@ -1,0 +1,22 @@
+/**
+ * Local/dev-only feedback prompt overrides (power-user testing without visit gates).
+ * Set NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS=hakmeh2020@gmail.com in .env.local
+ */
+export function getFeedbackDevForceEmails(): Set<string> {
+  const raw =
+    (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS) ||
+    '';
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+export function isFeedbackDevForceEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  // Client bundle only gets NEXT_PUBLIC_* — restrict to non-production builds.
+  if (process.env.NODE_ENV === 'production') return false;
+  return getFeedbackDevForceEmails().has(email.trim().toLowerCase());
+}

--- a/app/lib/feedback/eligibility.ts
+++ b/app/lib/feedback/eligibility.ts
@@ -1,0 +1,99 @@
+import type { FeedbackSurface } from './types';
+
+const VISITS_KEY = 'pp_feedback_dashboard_visits_v1';
+const SNOOZE_KEY = 'pp_feedback_prompt_snooze_v1';
+const DISMISSED_KEY = 'pp_feedback_prompt_dismissed_v1';
+
+type VisitState = { timestamps: number[] };
+
+function readJson(key: string): any | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(key: string, value: unknown) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore quota errors; feedback prompting must not block product UX
+  }
+}
+
+export function recordDashboardVisit(now = Date.now()) {
+  if (typeof window === 'undefined') return;
+  const state = (readJson(VISITS_KEY) as VisitState | null) ?? { timestamps: [] };
+  const next = {
+    timestamps: Array.isArray(state.timestamps) ? state.timestamps.concat([now]) : [now],
+  };
+  writeJson(VISITS_KEY, next);
+}
+
+export function dashboardVisitCountInWindow(opts?: { now?: number; windowDays?: number }): number {
+  if (typeof window === 'undefined') return 0;
+  const now = opts?.now ?? Date.now();
+  const windowDays = Math.max(1, Math.min(opts?.windowDays ?? 7, 30));
+  const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
+  const state = (readJson(VISITS_KEY) as VisitState | null) ?? { timestamps: [] };
+  const ts = Array.isArray(state.timestamps) ? state.timestamps : [];
+  const pruned = ts.filter((t) => typeof t === 'number' && Number.isFinite(t) && t >= cutoff && t <= now);
+  if (pruned.length !== ts.length) writeJson(VISITS_KEY, { timestamps: pruned });
+  return pruned.length;
+}
+
+export function snoozeFeedbackPrompt(days = 7, now = Date.now()) {
+  if (typeof window === 'undefined') return;
+  const ms = Math.max(1, Math.min(days, 30)) * 24 * 60 * 60 * 1000;
+  try {
+    localStorage.setItem(SNOOZE_KEY, String(now + ms));
+  } catch {
+    // ignore
+  }
+}
+
+export function dismissFeedbackPromptPermanently() {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(DISMISSED_KEY, '1');
+  } catch {
+    // ignore
+  }
+}
+
+export function isFeedbackPromptSnoozedOrDismissed(now = Date.now()): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    if (localStorage.getItem(DISMISSED_KEY) === '1') return true;
+    const snoozeUntilRaw = localStorage.getItem(SNOOZE_KEY);
+    const snoozeUntil = snoozeUntilRaw ? Number.parseInt(snoozeUntilRaw, 10) : 0;
+    return Number.isFinite(snoozeUntil) && snoozeUntil > now;
+  } catch {
+    return false;
+  }
+}
+
+export function shouldPromptForFeedback(params: {
+  isAuthenticated: boolean;
+  surface: FeedbackSurface;
+  now?: number;
+  minDashboardVisitsInWindow?: number;
+  windowDays?: number;
+}): { eligible: boolean; visitCount: number } {
+  const now = params.now ?? Date.now();
+  if (!params.isAuthenticated) return { eligible: false, visitCount: 0 };
+  if (params.surface !== 'pocket') {
+    // Feedback prompt is a Pocket harness mechanism; Open surface is receipts consumer.
+    return { eligible: false, visitCount: 0 };
+  }
+  if (isFeedbackPromptSnoozedOrDismissed(now)) {
+    return { eligible: false, visitCount: dashboardVisitCountInWindow({ now, windowDays: params.windowDays }) };
+  }
+  const visitCount = dashboardVisitCountInWindow({ now, windowDays: params.windowDays });
+  const min = Math.max(1, Math.min(params.minDashboardVisitsInWindow ?? 5, 50));
+  return { eligible: visitCount >= min, visitCount };
+}
+

--- a/app/lib/feedback/scrub.ts
+++ b/app/lib/feedback/scrub.ts
@@ -1,0 +1,120 @@
+import type { ScrubbedText, ScrubRedactionKind } from './types';
+
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+// Permissive; keyword-gated rules should handle most true PII. This is a safety net.
+const PHONE_RE =
+  /\b(?:\+?\d{1,3}[\s.-]?)?(?:\(?\d{2,4}\)?[\s.-]?)?\d{3,4}[\s.-]?\d{3,4}\b/g;
+const IBAN_RE = /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/gi;
+const CARD_SHAPE_RE = /\b(?:\d[ -]*?){13,19}\b/g;
+const ACCOUNT_KEYWORD_RE =
+  /\b(?:account(?:\s*number)?|acct|sort\s*code|routing|aba|swift|bic)\b/gi;
+const ACCOUNT_CAPTURE_RE =
+  /\b(?:account(?:\s*number)?|acct|sort\s*code|routing|aba|swift|bic)\b[^\n]{0,32}\b([A-Z0-9][A-Z0-9 -]{5,})\b/gi;
+const ADDRESS_LINE_RE =
+  /\b(?:address|street|st\.|road|rd\.|avenue|ave\.|postcode|zip)\b[^\n]{0,120}/gi;
+const LONG_DIGITS_RE = /\b\d{10,}\b/g;
+const AMOUNT_RE = /(?:£|\$|€)\s?\d{1,3}(?:,\d{3})+(?:\.\d{2})?/g;
+
+function normalizeInput(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/[ \t]{2,}/g, ' ').trim();
+}
+
+function addCount(counts: Map<ScrubRedactionKind, number>, kind: ScrubRedactionKind, n: number) {
+  if (n <= 0) return;
+  counts.set(kind, (counts.get(kind) ?? 0) + n);
+}
+
+function countMatches(text: string, re: RegExp): number {
+  const m = text.match(re);
+  return m ? m.length : 0;
+}
+
+function redactByRegex(
+  input: string,
+  re: RegExp,
+  kind: ScrubRedactionKind,
+  replacement: string,
+  counts: Map<ScrubRedactionKind, number>
+): string {
+  const n = countMatches(input, re);
+  if (n > 0) addCount(counts, kind, n);
+  return input.replace(re, replacement);
+}
+
+function redactLedgerRows(input: string, counts: Map<ScrubRedactionKind, number>): string {
+  const lines = input.split('\n');
+  let changed = 0;
+  const out = lines.map((line) => {
+    const commaCount = (line.match(/,/g) ?? []).length;
+    const semiCount = (line.match(/;/g) ?? []).length;
+    const tabCount = (line.match(/\t/g) ?? []).length;
+    const isLedgerLike = commaCount >= 6 || semiCount >= 6 || tabCount >= 6;
+    if (!isLedgerLike) return line;
+    changed += 1;
+    return '[REDACTED:LEDGER_ROW]';
+  });
+  if (changed) addCount(counts, 'LEDGER_ROW', changed);
+  return out.join('\n');
+}
+
+function redactCardLike(input: string, counts: Map<ScrubRedactionKind, number>): string {
+  const matches = input.match(CARD_SHAPE_RE) ?? [];
+  let valid = 0;
+  for (const m of matches) {
+    const digits = m.replace(/[^\d]/g, '');
+    if (digits.length >= 13 && digits.length <= 19) valid += 1;
+  }
+  if (valid > 0) addCount(counts, 'CARD', valid);
+  // Replace all card-shape matches; we already guarded counts to avoid overstating.
+  return input.replace(CARD_SHAPE_RE, '[REDACTED:CARD]');
+}
+
+function redactAccountIds(input: string, counts: Map<ScrubRedactionKind, number>): string {
+  // Only attempt capture replacement if keyword present to reduce false positives.
+  if (!ACCOUNT_KEYWORD_RE.test(input)) return input;
+  ACCOUNT_KEYWORD_RE.lastIndex = 0;
+  const n = countMatches(input, ACCOUNT_CAPTURE_RE);
+  if (n > 0) addCount(counts, 'ACCOUNT_ID', n);
+  return input.replace(ACCOUNT_CAPTURE_RE, (full, captured) => {
+    if (!captured) return full;
+    return full.replace(captured, '[REDACTED:ACCOUNT_ID]');
+  });
+}
+
+export function scrubFeedbackText(raw: string, opts?: { maxChars?: number }): ScrubbedText {
+  const original = String(raw ?? '');
+  const counts = new Map<ScrubRedactionKind, number>();
+  const maxChars = Math.max(200, Math.min(opts?.maxChars ?? 4000, 12000));
+
+  let text = normalizeInput(original);
+
+  let truncated = false;
+  if (text.length > maxChars) {
+    text = text.slice(0, maxChars);
+    truncated = true;
+    addCount(counts, 'TRUNCATED', 1);
+  }
+
+  // Order matters: email before phone; ledger rows before long digits.
+  text = redactByRegex(text, EMAIL_RE, 'EMAIL', '[REDACTED:EMAIL]', counts);
+  text = redactByRegex(text, PHONE_RE, 'PHONE', '[REDACTED:PHONE]', counts);
+  text = redactByRegex(text, IBAN_RE, 'IBAN', '[REDACTED:IBAN]', counts);
+  text = redactCardLike(text, counts);
+  text = redactAccountIds(text, counts);
+  text = redactByRegex(text, ADDRESS_LINE_RE, 'ADDRESS_LINE', '[REDACTED:ADDRESS_LINE]', counts);
+  text = redactLedgerRows(text, counts);
+  text = redactByRegex(text, LONG_DIGITS_RE, 'LONG_ID', '[REDACTED:LONG_ID]', counts);
+  text = redactByRegex(text, AMOUNT_RE, 'AMOUNT', '[REDACTED:AMOUNT]', counts);
+
+  const redactions = Array.from(counts.entries()).map(([kind, count]) => ({ kind, count }));
+  return {
+    text,
+    meta: {
+      redactions,
+      truncated,
+      originalLength: original.length,
+      finalLength: text.length,
+    },
+  };
+}
+

--- a/app/lib/feedback/templates.ts
+++ b/app/lib/feedback/templates.ts
@@ -1,0 +1,88 @@
+import type { FeedbackTemplate } from './types';
+
+export const FEEDBACK_TEMPLATES: FeedbackTemplate[] = [
+  {
+    id: 'signal_local_first_speed',
+    kind: 'signal',
+    label: 'Local-first feels instant',
+    draft:
+      'Dashboard is responsive and the local-first flow feels instant. Import → insights was smooth.',
+  },
+  {
+    id: 'signal_clean_import_first_pass',
+    kind: 'signal',
+    label: 'CSV import worked first pass',
+    draft:
+      'My broker export imported cleanly on the first pass. Column mapping didn’t need manual edits.',
+  },
+  {
+    id: 'signal_trust_boundary_clear',
+    kind: 'signal',
+    label: 'Boundary is clear',
+    draft:
+      'The sovereignty boundary is clear: I understand what stays local vs what crosses the wire.',
+  },
+  {
+    id: 'signal_admin_ready_export',
+    kind: 'signal',
+    label: 'Export is audit-friendly',
+    draft: 'The export and reporting surfaces feel audit-friendly and easy to validate.',
+  },
+  {
+    id: 'friction_mapping_confusing',
+    kind: 'friction',
+    label: 'Mapping needed work',
+    draft:
+      'I had to adjust column mapping manually. The UI could better explain what it inferred and why.',
+  },
+  {
+    id: 'friction_dashboard_navigation',
+    kind: 'friction',
+    label: 'Dashboard navigation friction',
+    draft:
+      'Finding key actions in the dashboard took too long. I had to click around to locate imports/insights.',
+  },
+  {
+    id: 'friction_context_explanation',
+    kind: 'friction',
+    label: 'Context explanation unclear',
+    draft:
+      'I’m not fully sure what the context engine included/excluded. I want a clearer preview of the aggregate.',
+  },
+  {
+    id: 'friction_performance_jank',
+    kind: 'friction',
+    label: 'Performance jank',
+    draft: 'Scrolling or switching tabs felt janky on my machine. I saw noticeable UI lag.',
+  },
+  {
+    id: 'break_parser_failure',
+    kind: 'break',
+    label: 'Parser failed on export',
+    draft:
+      'The parser failed on my broker export. Import didn’t complete and I couldn’t recover without retrying.',
+  },
+  {
+    id: 'break_context_missed_data',
+    kind: 'break',
+    label: 'Context missed data',
+    draft:
+      'The context engine missed positions/trades I expected to see reflected in the summary.',
+  },
+  {
+    id: 'break_quotes_or_market_data',
+    kind: 'break',
+    label: 'Market data broke',
+    draft: 'Quotes/market data failed to load or showed stale values. It blocked verification.',
+  },
+  {
+    id: 'break_auth_or_sync',
+    kind: 'break',
+    label: 'Auth/sync broke',
+    draft:
+      'Sign-in or sync behavior broke (loop, stale state, or unexpected logout). It prevented normal use.',
+  },
+];
+
+export const FEEDBACK_TEMPLATE_IDS = new Set(FEEDBACK_TEMPLATES.map((t) => t.id));
+

--- a/app/lib/feedback/types.ts
+++ b/app/lib/feedback/types.ts
@@ -1,0 +1,64 @@
+export type FeedbackSurface = 'pocket' | 'open';
+
+export type FeedbackFriction = 'frictionless' | 'broken';
+
+export type FeedbackSeverityClass = 'P0' | 'P1' | 'P2';
+
+export type FeedbackTierBand = 'free' | 'foundersClub' | 'corporateSponsor' | 'unknown';
+
+export type FeedbackCategory =
+  | 'signal_local_first_speed'
+  | 'signal_clean_import_first_pass'
+  | 'signal_trust_boundary_clear'
+  | 'signal_admin_ready_export'
+  | 'friction_mapping_confusing'
+  | 'friction_dashboard_navigation'
+  | 'friction_context_explanation'
+  | 'friction_performance_jank'
+  | 'break_parser_failure'
+  | 'break_context_missed_data'
+  | 'break_quotes_or_market_data'
+  | 'break_auth_or_sync'
+  | 'other';
+
+export type FeedbackTemplateKind = 'signal' | 'friction' | 'break';
+
+export type FeedbackTemplate = {
+  id: FeedbackCategory;
+  kind: FeedbackTemplateKind;
+  label: string;
+  draft: string;
+};
+
+export type ScrubRedactionKind =
+  | 'EMAIL'
+  | 'PHONE'
+  | 'IBAN'
+  | 'CARD'
+  | 'ACCOUNT_ID'
+  | 'ADDRESS_LINE'
+  | 'LEDGER_ROW'
+  | 'LONG_ID'
+  | 'AMOUNT'
+  | 'TRUNCATED';
+
+export type ScrubbedTextMeta = {
+  redactions: Array<{ kind: ScrubRedactionKind; count: number }>;
+  truncated: boolean;
+  originalLength: number;
+  finalLength: number;
+};
+
+export type ScrubbedText = {
+  text: string;
+  meta: ScrubbedTextMeta;
+};
+
+export type FeedbackSubmissionDraft = {
+  surface: FeedbackSurface;
+  rating: number; // 1..5
+  friction: FeedbackFriction;
+  category: FeedbackCategory;
+  comment: string;
+};
+

--- a/app/open/_components/OpenLandingClient.tsx
+++ b/app/open/_components/OpenLandingClient.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { useRef } from 'react';
+import { VerifiedReceiptsSection } from '@/app/components/landing/VerifiedReceiptsSection';
 import OpenContactForm from './OpenContactForm';
 import OpenLandingProofVideo from './OpenLandingProofVideo';
 import OpenLandingVisual from './OpenLandingVisual';
@@ -648,6 +649,12 @@ function BoardMoatSection({
           </Link>
         </motion.div>
       </motion.div>
+
+      <VerifiedReceiptsSection
+        surface="open"
+        title="Verified receipts (operator-grade)"
+        subtitle="Curated feedback from the live harness — focused on compliance, procurement velocity, and boundary clarity."
+      />
     </section>
   );
 }

--- a/docs/command/feedback-substrate-prod-readiness-2026-07-16.md
+++ b/docs/command/feedback-substrate-prod-readiness-2026-07-16.md
@@ -1,0 +1,240 @@
+---
+id: PP-FEEDBACK-SUBSTRATE-PROD-READINESS-2026-07-16
+title: Feedback Substrate — Production Readiness & Command Decision Brief
+status: READY_FOR_COLLECTIVE_DECISION
+last_updated: 2026-07-16
+roles: [CEO, CPO, Head of Product Engineering, Head of AI & Community Ops, DevOps]
+spec_ssot: docs/command/feedback-substrate-spec-2026-06-16.md
+deploy_gates: docs/command/deploy-production-gates.md
+---
+
+# Feedback Substrate — Production Readiness Report
+
+**Verdict:** Implementation is **complete for Phase 1 local scope**. Production build **succeeds**. Ship is a **collective go / hold / staged** decision — not an engineering blocker.
+
+---
+
+## 1. Executive summary
+
+| Item | Status |
+|------|--------|
+| Phase 0 spec annex | Locked (`34ae50c3`) |
+| End-to-end Phase 1 build | Done (local validated) |
+| `npm run lint` | Pass |
+| `npm run typecheck` | Pass |
+| `npm run build` (production) | Pass (exit 0, ~2m) |
+| Firestore rules (repo) | Updated for 4 collections |
+| Code committed / PR | **Not yet** — uncommitted on `main` |
+| Firestore rules deployed to prod | **Pending** (ops action) |
+| Prod env vars set on Vercel | **Pending** (ops action) |
+| P0 email delivery verified in prod | **Pending** (local test showed email fail — Resend/domain) |
+
+**Bottom line:** Code is build-ready. Production cutover requires commit + deploy + rules + env + one live P0 smoke.
+
+---
+
+## 2. What shipped (capability map)
+
+### 2.1 User path (B2C dashboard)
+
+- Visit counter in `localStorage` (`>5 /dashboard` visits in 7 days)
+- Modal precedence over onboarding / feature announcement
+- UI: 1–5 scale + Frictionless/Broken + 12 adversarial templates + free text
+- Client + server PII scrub before persistence
+- Dev-only force trigger (`NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS`) — **hard-disabled when `NODE_ENV === 'production'`**
+
+### 2.2 Write path & dual store
+
+| Collection | Role |
+|------------|------|
+| `feedbackSubmissions` | Admin vault (scrubbed text, triage, CMS source) |
+| `feedbackEvents` | Analytics metadata only (no free text) |
+| `featuredReceipts` | Public CMS index (`surface = pocket \| open`) |
+| `feedbackAlertDeliveries` | P0 delivery log (email + webhook) |
+
+- `anonUserHash = HMAC(uid, FEEDBACK_ANON_PEPPER \| ENCRYPTION_SECRET)`
+- P0 severity router on `POST /api/feedback/submit` (not analytics poll)
+- KV 24h dedup for P0 alerts
+
+### 2.3 Admin CMS (`/admin/analytics` → Feedback Substrate)
+
+- Submissions queue split: **Awaiting curation** vs **Curated — vault copy retained**
+- Promote → Pocket / Open (copy to public index; vault retained by design)
+- Featured badges; promote disabled per surface once linked
+- Edit / Remove featured receipts
+- P0 alert delivery log + telemetry metric cards
+
+### 2.4 Public landings
+
+- `VerifiedReceiptsSection` on Pocket (`/`, `/landing`) and Open (`/open`)
+- Up to 12 receipts; responsive grid (1 centered; 2+ auto-fit columns)
+- Empty / error → section hidden (no broken UI)
+
+### 2.5 API surface (present in prod build)
+
+| Route | Auth |
+|-------|------|
+| `POST /api/feedback/submit` | Authenticated user |
+| `GET /api/feedback/featured?surface=` | Public |
+| `GET /api/admin/feedback/submissions` | Admin |
+| `GET /api/admin/feedback/alerts` | Admin |
+| `POST /api/admin/feedback/curate` | Admin |
+
+Public featured responses **do not** expose `sourceSubmissionId` / anon hashes.
+
+---
+
+## 3. Verification evidence (2026-07-16)
+
+```
+npm run lint        → pass (0 warnings/errors)
+npm run typecheck   → pass (exit 0)
+npm run build       → pass (exit 0, ~121s)
+```
+
+Build includes all five feedback API routes. Local smoke previously confirmed: modal submit, admin queue, promote → landing render, curation UI status.
+
+---
+
+## 4. Production gates — checklist for go-live
+
+### 4.1 Must do before / with deploy (blockers)
+
+| # | Gate | Owner | Notes |
+|---|------|-------|-------|
+| G1 | Commit + PR feedback substrate only (narrow diff) | Eng | Large dirty tree on `main`; do **not** bundle seed/marketing noise |
+| G2 | Deploy updated `firebase/firestore.rules` | DevOps | Collections: submissions, events, featured, alertDeliveries |
+| G3 | Set Vercel prod env | DevOps | See §5 |
+| G4 | Confirm Resend can send from alert `from` domain | Ops | Local P0 showed `email: fail` — verify domain + `FEEDBACK_ALERT_FROM` |
+| G5 | Post-deploy smoke | Eng + Community | §6 |
+
+### 4.2 Should do (same release train preferred)
+
+| # | Gate | Owner |
+|---|------|-------|
+| S1 | Optional `FEEDBACK_P0_WEBHOOK_URL` (Slack/Discord) | Ops |
+| S2 | Dedicated `FEEDBACK_ANON_PEPPER` (don’t rely only on `ENCRYPTION_SECRET`) | Security |
+| S3 | Curate ≥1 Pocket + ≥1 Open receipt with intentional quotes (no mismatched taglines) | Community Ops |
+| S4 | Confirm `NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS` is **unset** in Vercel prod | DevOps |
+
+### 4.3 Explicit non-blockers
+
+- Moving featured store from Firestore → Edge KV (spec preferred; Firestore is acceptable for Phase 1 volume)
+- Hiding curated vault rows entirely (current: retained + labeled — correct GRC posture)
+- Automated e2e Playwright suite for feedback (manual smoke sufficient for first prod)
+
+---
+
+## 5. Production environment variables
+
+| Variable | Required | Default / fallback | Prod guidance |
+|----------|----------|--------------------|---------------|
+| `FEEDBACK_ENGINEERING_EMAIL` | Required | **`ai@pocketportfolio.app` only** | Sole operational inbox — no alternate engineering aliases |
+| `FEEDBACK_ANON_PEPPER` | Recommended | falls back to `ENCRYPTION_SECRET` | Set distinct pepper in prod |
+| `FEEDBACK_P0_WEBHOOK_URL` | Optional | unset → webhook logged as not configured | Add when channel ready |
+| `FEEDBACK_ALERT_FROM` | Optional | `Pocket Portfolio Alerts <ai@pocketportfolio.app>` | Same operational domain; must be Resend-verified |
+| `NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS` | **Omit in prod** | — | Dev-only; code also guards on `NODE_ENV` |
+| `ENCRYPTION_SECRET` | Already required | — | Pepper fallback |
+| `RESEND_API_KEY` | Already required for mail | — | P0 path depends on it |
+| Firebase Admin + KV | Already required | — | Dual-write + dedup |
+
+Also ensure existing: `ADMIN_EMAIL_OVERRIDE` / admin claims for CMS operators.
+
+---
+
+## 6. Post-deploy smoke plan (30 minutes)
+
+1. **Submit** — signed-in user on `pocketportfolio.app/dashboard?showFeedbackModal=true` → submit frictionless + broken cases.
+2. **Admin** — `/admin/analytics` → Feedback Substrate shows both submissions; metrics non-zero.
+3. **P0** — broken/parser-style category → `feedbackAlertDeliveries` shows `email.ok: true` (fix Resend if fail).
+4. **Curate** — Promote one quote → Pocket; confirm badge + buttons hide for that surface; vault row moves to Curated section.
+5. **Public B2C** — `pocketportfolio.app/` and `/landing` show Verified receipts.
+6. **Public B2B** — `openportfolio.co.uk/` shows Open-surface receipts only.
+7. **Negative** — unfeatured / expired receipts disappear from public API; section hides when empty.
+
+---
+
+## 7. Known issues & residual risk
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| P0 email failed in local test | **High for ops** | Fix Resend domain/`FEEDBACK_ALERT_FROM` before trusting pager path |
+| Uncommitted mega-workspace | Medium | Narrow PR; exclude videos/tmp/seed artefacts |
+| Quote/tagline mismatch on promote | Low | Admin Edit on featured receipt; operators own copy quality |
+| Composite Firestore indexes | Low | Featured API already falls back to in-memory filter/sort |
+| Client-only visit eligibility | Accepted | Spec non-negotiable; can be gamed — acceptable for Phase 1 |
+| Public `featuredReceipts` readable by clients | Accepted | No PII by construction; server writes only |
+
+---
+
+## 8. Decision options for the Command Team
+
+### Option A — **GO (full prod)** this release train
+
+Ship feedback substrate with dual-surface landings + admin CMS + P0 router after G1–G5.
+
+**Recommend if:** Community Ops is ready to curate; Resend alert path is fixed; DevOps can deploy rules same day.
+
+### Option B — **STAGED** (recommended default)
+
+1. Deploy code + rules with **feature live** but **no featured receipts** (landings hide empty section).
+2. Soft-launch: internal accounts only for 48–72h; verify P0 email.
+3. Curate first public receipts intentionally; then announce.
+
+**Recommend if:** Want ops confidence on alert delivery before public social proof.
+
+### Option C — **HOLD** code behind branch until Resend + pepper + rules confirmed
+
+Merge only after G2–G4 green in a preview environment.
+
+**Recommend if:** Capital/ops attention is on seed/outreach this week and feedback is not on the critical path.
+
+---
+
+## 9. Role-specific asks
+
+| Role | Ask |
+|------|-----|
+| **CEO** | Choose A / B / C; confirm `ai@pocketportfolio.app` remains P0 inbox |
+| **CPO** | Approve public copy posture (“Verified receipts · curated”) and first curated quotes |
+| **Head of Product Engineering** | Own narrow PR + post-deploy smoke §6 |
+| **Head of AI & Community Ops** | Own curation queue cadence; first Pocket + Open receipts; watch P0 inbox |
+| **DevOps** | Vercel env (§5), Firestore rules deploy, confirm Resend from-domain |
+
+---
+
+## 10. Suggested next-step sequence (if Option B)
+
+1. Eng: commit feedback substrate + firestore rules + `.env.example` only → PR → merge.
+2. DevOps: set prod env; deploy rules; promote Vercel production.
+3. Eng: run smoke §6 on prod; paste results into this doc’s appendix.
+4. Community Ops: curate first receipts; remove any test/mismatched quotes.
+5. Command: 48h review — keep live, tune trigger threshold, or pause modal via env flag (future) if noise.
+
+---
+
+## Appendix A — Key paths
+
+| Area | Path |
+|------|------|
+| Spec | `docs/command/feedback-substrate-spec-2026-06-16.md` |
+| Client lib | `app/lib/feedback/` |
+| Modal | `app/components/feedback/FeedbackModal.tsx` |
+| Landing | `app/components/landing/VerifiedReceiptsSection.tsx` |
+| Submit | `app/api/feedback/submit/route.ts` |
+| Featured public | `app/api/feedback/featured/route.ts` |
+| Admin curate | `app/api/admin/feedback/curate/route.ts` |
+| Admin UI | `app/admin/analytics/page.tsx` |
+| Rules | `firebase/firestore.rules` |
+
+## Appendix B — Build attestation
+
+- Date: **2026-07-16**
+- Branch: `main` (uncommitted feedback delta present)
+- `npm run lint` → pass
+- `npm run typecheck` → pass
+- `npm run build` → pass (exit 0)
+
+---
+
+*Prepared for Command Team collective decision. Spec remains PHASE_0_LOCKED; this brief does not reopen locked non-negotiables.*

--- a/docs/command/feedback-substrate-spec-2026-06-16.md
+++ b/docs/command/feedback-substrate-spec-2026-06-16.md
@@ -1,0 +1,295 @@
+---
+id: PP-FEEDBACK-SUBSTRATE-SPEC-2026-06-16
+title: Pocket Portfolio — In-App Feedback Substrate (Phase 0 Spec Annex)
+status: PHASE_0_LOCKED
+last_updated: 2026-06-16
+roles: [CEO, Engineering, Product, Growth, Procurement-facing]
+governance_ssot: docs/command/claims-vs-codebase-calibration.md
+---
+
+# Feedback Substrate — Phase 0 Spec Annex (Locked)
+
+This annex locks the Phase 0 specification for Pocket Portfolio’s in-app feedback substrate: **power-user telemetry → P0 alert router → admin CMS curation → public receipts**.
+
+**Calibration SSOT:** `docs/command/claims-vs-codebase-calibration.md` (dual-surface reality, stateless boundary language).
+
+---
+
+## 0. Non-negotiables (GRC posture)
+
+- **Eligibility tracking is client-side only.** The `>5 /dashboard visits in 7 days` trigger is calculated in `localStorage`/`IndexedDB`. We do **not** send un-triggered navigation telemetry to servers.
+- **PII guardrails run before network egress.** Free-text is scrubbed client-side prior to submit. The server repeats a conservative scrub (defence-in-depth) before persistence.
+- **Dual-store split is mandatory:**
+  - `feedbackSubmissions`: admin vault + CMS queue + alert router input (scrubbed text allowed).
+  - `feedbackEvents`: analytics metadata only (no text, no uid, no email, no portfolio context).
+- **Identity masking is mandatory:** `anonUserHash = HMAC(uid, serverPepper)` on the server. No raw uid in analytics collections.
+- **Alert engine runs on the write path** (`POST /api/feedback/submit`), not in `/admin/analytics`.
+
+---
+
+## 1. Surface routing invariants (locked)
+
+We operate **one monorepo** + **one deployment** with **host-aware routing**.
+
+- **B2C receipts render target:** `pocketportfolio.app` → `/` and `/landing`.
+- **B2B receipts render target:** `openportfolio.co.uk` → `/open` (Open surface; host middleware rewrites).
+
+The CMS publish layer must tag receipts with `surface = pocket | open` and only surface the matching set on each landing.
+
+---
+
+## 2. UI spec (Phase 1 build target)
+
+### 2.1 Rating controls (analytical, chartable)
+
+- **Primary:** 1–5 integer scale (stored as `rating` integer).
+- **Binary toggle:** `friction = frictionless | broken`.
+
+### 2.2 Comment capture
+
+- Single free-text field (scrubbed) for “what happened / what broke / what you expected”.
+- Optional category chip selection (from adversarial templates list below) to avoid relying on NLP.
+
+---
+
+## 3. Data model (collections) — authoritative shapes
+
+### 3.1 `feedbackSubmissions` (admin vault)
+
+**Purpose:** CMS queue + P0 routing + operational triage. Stored in Firestore via Admin SDK.
+
+**Must include:**
+
+- `createdAt` (timestamp)
+- `surface` (`pocket` | `open`)
+- `rating` (1–5 int)
+- `friction` (`frictionless` | `broken`)
+- `category` (one of the 12 template IDs, or `other`)
+- `commentScrubbed` (string, scrubbed)
+- `commentScrubMeta` (object, see §4.3)
+- `anonUserHash` (string: HMAC(uid, pepper))
+- `tierBand` (`free` | `foundersClub` | `corporateSponsor` | `unknown`)
+- `appVersion` (optional; from build metadata if available)
+- `dashboardVisitWindow` (optional; count + window days, no timestamps)
+
+**Must not include:**
+
+- raw uid, email, portfolio context, CSV contents, file attachments, account numbers, addresses.
+
+### 3.2 `feedbackEvents` (analytics metadata only)
+
+**Purpose:** bounded aggregation for `/admin/analytics`.
+
+**Allowed fields only (no text):**
+
+- `createdAt`
+- `surface`
+- `rating`
+- `friction`
+- `category`
+- `severityClass` (`P0` | `P1` | `P2`)
+- `tierBand`
+- `dedupedAlert` (boolean)
+
+### 3.3 `featuredReceipts` (public index)
+
+**Purpose:** public landing rendering (B2C/B2B). Storage target: Edge KV (preferred) or Firestore doc.
+
+**Allowed fields only:**
+
+- `surface`
+- `quote` (curated excerpt, manually edited by admin)
+- `rating` (optional)
+- `tagline` (optional; e.g. “CSV import”, “Sovereign inference boundary”)
+- `featuredAt`
+- `lastEditedAt`
+
+**Explicitly removed:** internal IDs, anon hashes, timestamps beyond display, admin notes.
+
+---
+
+## 4. PII scrubber — explicit rules (Phase 0 locked)
+
+### 4.1 Approach
+
+Scrubber runs **client-side** before submit and **server-side** before write. It is a conservative redaction layer designed to prevent accidental leakage of:
+
+- account identifiers
+- addresses / phone numbers
+- emails
+- raw ledger rows / export dumps
+- unusually specific financial values pasted verbatim
+
+We do not claim perfect PII detection; we claim **bounded egress controls** with defence-in-depth.
+
+### 4.2 Normalization
+
+Before regex passes:
+
+- Convert `\r\n` to `\n`
+- Collapse excessive whitespace (`[ \t]{2,}` → single space) but preserve line breaks
+- Cap max length (client hard cap; server hard cap)
+
+### 4.3 Redaction outputs (required)
+
+Return:
+
+- `text` (scrubbed)
+- `meta`:
+  - `redactions`: array of `{ kind, count }`
+  - `truncated`: boolean
+  - `originalLength`: number
+  - `finalLength`: number
+
+### 4.4 Regex rules (apply in order)
+
+> Implementation guidance: use case-insensitive matching where indicated; prefer global matches; avoid catastrophic backtracking.
+
+#### A) Email addresses
+
+- **Pattern:** `(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b`
+- **Replace:** `[REDACTED:EMAIL]`
+
+#### B) Phone numbers (UK/US-ish, permissive)
+
+- **Pattern:** `(?i)\b(?:\+?\d{1,3}[\s.-]?)?(?:\(?\d{2,4}\)?[\s.-]?)?\d{3,4}[\s.-]?\d{3,4}\b`
+- **Replace:** `[REDACTED:PHONE]`
+- **Note:** Run after email; do not attempt full international coverage in v1.
+
+#### C) IBAN
+
+- **Pattern:** `(?i)\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b`
+- **Replace:** `[REDACTED:IBAN]`
+
+#### D) Payment cards (basic Luhn-like shape; no checksum in v1)
+
+- **Pattern:** `\b(?:\d[ -]*?){13,19}\b`
+- **Replace:** `[REDACTED:CARD]`
+- **Guard:** Only redact if the match contains at least 13 digits after stripping spaces/hyphens.
+
+#### E) Account / sort code / routing identifiers (keyword-gated)
+
+- **Pattern:** `(?i)\b(?:account(?:\s*number)?|acct|sort\s*code|routing|aba|swift|bic)\b[^\n]{0,32}\b([A-Z0-9][A-Z0-9 -]{5,})\b`
+- **Replace:** `$0` with the captured identifier replaced by `[REDACTED:ACCOUNT_ID]`
+
+#### F) Address-like lines (conservative, keyword-gated)
+
+- **Pattern:** `(?i)\b(?:address|street|st\.|road|rd\.|avenue|ave\.|postcode|zip)\b[^\n]{0,120}`
+- **Replace:** `[REDACTED:ADDRESS_LINE]`
+
+#### G) Raw CSV/ledger row dumps (line heuristic)
+
+If any line matches **either** heuristic, redact the whole line:
+
+- **Comma-heavy row:** line contains `,` at least 6 times (`/(?:.*,){6,}.*/`)
+- **Delimiter row:** line contains `;` at least 6 times or `\t` at least 6 times
+
+**Replace line with:** `[REDACTED:LEDGER_ROW]`
+
+#### H) Long digit sequences (unknown identifiers)
+
+- **Pattern:** `\b\d{10,}\b`
+- **Replace:** `[REDACTED:LONG_ID]`
+
+#### I) Extreme monetary values (optional, cautious)
+
+- **Pattern:** `(?i)(?:£|\$|€)\s?\d{1,3}(?:,\d{3})+(?:\.\d{2})?`
+- **Replace:** `[REDACTED:AMOUNT]`
+- **Note:** Only redact the formatted large-number pattern; do not blanket-redact all amounts.
+
+---
+
+## 5. Adversarial template matrix (12 total — locked)
+
+Templates are deterministic buttons/chips that prefill category + optional draft text. They are designed to preserve a mathematically balanced spectrum: **Signal (4) / Friction (4) / Break (4)**.
+
+### 5.1 Signal (4)
+
+1. **signal_local_first_speed**
+   - Label: “Local-first feels instant”
+   - Draft: “Dashboard is responsive and the local-first flow feels instant. Import → insights was smooth.”
+2. **signal_clean_import_first_pass**
+   - Label: “CSV import worked first pass”
+   - Draft: “My broker export imported cleanly on the first pass. Column mapping didn’t need manual edits.”
+3. **signal_trust_boundary_clear**
+   - Label: “Boundary is clear”
+   - Draft: “The sovereignty boundary is clear: I understand what stays local vs what crosses the wire.”
+4. **signal_admin_ready_export**
+   - Label: “Export is audit-friendly”
+   - Draft: “The export and reporting surfaces feel audit-friendly and easy to validate.”
+
+### 5.2 Friction (4)
+
+5. **friction_mapping_confusing**
+   - Label: “Mapping needed work”
+   - Draft: “I had to adjust column mapping manually. The UI could better explain what it inferred and why.”
+6. **friction_dashboard_navigation**
+   - Label: “Dashboard navigation friction”
+   - Draft: “Finding key actions in the dashboard took too long. I had to click around to locate imports/insights.”
+7. **friction_context_explanation**
+   - Label: “Context explanation unclear”
+   - Draft: “I’m not fully sure what the context engine included/excluded. I want a clearer preview of the aggregate.”
+8. **friction_performance_jank**
+   - Label: “Performance jank”
+   - Draft: “Scrolling or switching tabs felt janky on my machine. I saw noticeable UI lag.”
+
+### 5.3 Break (4)
+
+9. **break_parser_failure**
+   - Label: “Parser failed on export”
+   - Draft: “The parser failed on my broker export. Import didn’t complete and I couldn’t recover without retrying.”
+10. **break_context_missed_data**
+   - Label: “Context missed data”
+   - Draft: “The context engine missed positions/trades I expected to see reflected in the summary.”
+11. **break_quotes_or_market_data**
+   - Label: “Market data broke”
+   - Draft: “Quotes/market data failed to load or showed stale values. It blocked verification.”
+12. **break_auth_or_sync**
+   - Label: “Auth/sync broke”
+   - Draft: “Sign-in or sync behavior broke (loop, stale state, or unexpected logout). It prevented normal use.”
+
+---
+
+## 6. P0 severity routing (write-path only)
+
+**Location:** `POST /api/feedback/submit`
+
+**P0 triggers (any):**
+
+- `friction === broken`
+- `rating <= 2` AND `category` in `{ break_parser_failure, break_context_missed_data, break_quotes_or_market_data, break_auth_or_sync }`
+- Lexical “break” triggers match (see §7) AND category is break-class OR user selected “break” chip
+
+**Dispatch:**
+
+- Email via Resend to `engineering@openportfolio.co.uk`
+- Optional webhook to Slack/Discord
+- Mandatory KV 24h dedup to prevent rage-click storms
+
+---
+
+## 7. `parser_failure` lexical triggers — disclosure guidance
+
+We maintain a **sanitized, non-exhaustive** lexicon for classifying likely parser failures without heavy observability tooling.
+
+**Internal implementation:** maintain a private list of patterns used to assign `break_parser_failure` when the user did not select a category chip.
+
+**External disclosure (procurement / partner):**
+
+- Share only a **sanitized excerpt** of trigger categories and intent (e.g. “parser failed”, “invalid header”, “unknown column”, “mapping error”), not the full regex list.
+- Do not share exact patterns that increase adversarial prompt/abuse surface.
+
+---
+
+## 8. Admin CMS freshness controls (required)
+
+Admin must be able to:
+
+- **Add** a receipt (promote a submission to featured)
+- **Edit** the public quote (manual rewrite for clarity; must preserve intent; no fabrication)
+- **Remove** a receipt (unfeature)
+- **Reorder** receipts (optional v1; required v1.1)
+- **Expire** receipts automatically (recommended): optional `expiresAt` to enforce freshness (e.g. 30–90 days)
+
+**Invariant:** Public receipts are **curated excerpts**, not raw submissions. All internal identifiers are stripped before publish.
+

--- a/docs/command/internal-feedback-system-report-2026-07-16.md
+++ b/docs/command/internal-feedback-system-report-2026-07-16.md
@@ -1,0 +1,195 @@
+---
+id: PP-INTERNAL-FEEDBACK-SYSTEM-REPORT-2026-07-16
+title: Internal Feedback System — Implementation Report (Commit Scope)
+status: DOCUMENTED — AWAITING COMMIT AUTHORIZATION
+last_updated: 2026-07-16
+roles: [CEO, CPO, Head of Product Engineering, Head of AI & Community Ops]
+spec_ssot: docs/command/feedback-substrate-spec-2026-06-16.md
+---
+
+# Internal Feedback System — Implementation Report
+
+**Purpose of this document:** Record exactly what was built, how it works, and **which files are in scope for the forthcoming commit/push**. Nothing outside this system is included.
+
+**Status:** Implementation complete. Lint / typecheck / production build verified. Command authorized surgical commit (2026-07-16). **Operational email lock: `ai@pocketportfolio.app` only.**
+
+---
+
+## 1. What this is
+
+An in-app **Internal Feedback System** (Feedback Substrate) for Pocket Portfolio:
+
+1. High-intent dashboard users are prompted for structured feedback.
+2. Scrubbed submissions land in an admin vault.
+3. P0 (break) signals alert engineering on the write path.
+4. Admins curate excerpts into public “Verified receipts” on B2C and B2B landings.
+
+It implements the locked Phase 0 annex: `docs/command/feedback-substrate-spec-2026-06-16.md` (commit `34ae50c3`).
+
+---
+
+## 2. Product behaviour (end-to-end)
+
+### 2.1 Capture (dashboard)
+
+- **Trigger:** `>5` `/dashboard` visits in a rolling 7-day window (client-side `localStorage` only — no navigation telemetry to servers).
+- **Override (local):** `?showFeedbackModal=true`; optional `NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS` (disabled when `NODE_ENV === 'production'`).
+- **UI:** 1–5 integer rating · Frictionless / Broken toggle · 12 adversarial category templates · free-text comment.
+- **PII:** Scrubbed client-side before submit; scrub repeated server-side before write.
+
+### 2.2 Persistence (dual store)
+
+| Collection | Contents |
+|------------|----------|
+| `feedbackSubmissions` | Admin vault — scrubbed text, category, rating, friction, `anonUserHash`, tier band |
+| `feedbackEvents` | Analytics metadata only — **no free text** |
+| `featuredReceipts` | Public CMS excerpts tagged `surface = pocket \| open` |
+| `feedbackAlertDeliveries` | P0 email/webhook delivery log |
+
+Identity on vault/events: `anonUserHash = HMAC(uid, pepper)` — never raw uid/email in analytics collections.
+
+### 2.3 P0 alerts
+
+- Severity classified on `POST /api/feedback/submit` (write path).
+- Email to `FEEDBACK_ENGINEERING_EMAIL` — **sole operational inbox: `ai@pocketportfolio.app`** (hard default; no secondary engineering aliases).
+- Default Resend From: `Pocket Portfolio Alerts <ai@pocketportfolio.app>` (override only with a verified `pocketportfolio.app` sender via `FEEDBACK_ALERT_FROM`).
+- Optional webhook via `FEEDBACK_P0_WEBHOOK_URL`.
+- 24h KV dedup per `(anonHash, category)`.
+
+### 2.4 Admin CMS (`/admin/analytics` → Feedback Substrate)
+
+- Submissions queue: **Awaiting curation** vs **Curated — vault copy retained**.
+- **Promote → Pocket / Open** copies a curated excerpt into `featuredReceipts` (vault row stays — by design for audit).
+- Badges when featured; promote disabled per surface once linked.
+- Edit / Remove featured receipts; P0 alert log; metric cards.
+
+### 2.5 Public landings
+
+- Component: `VerifiedReceiptsSection`.
+- **Pocket (B2C):** `/` and `/landing`.
+- **Open (B2B):** `/open` (host-aware Open surface).
+- Empty/error → section hidden.
+- Layout: 1 receipt centered; 2+ responsive CSS grid (up to 12).
+
+---
+
+## 3. API surface
+
+| Method | Route | Audience |
+|--------|-------|----------|
+| `POST` | `/api/feedback/submit` | Authenticated user |
+| `GET` | `/api/feedback/featured?surface=pocket\|open` | Public |
+| `GET` | `/api/admin/feedback/submissions` | Admin |
+| `GET` | `/api/admin/feedback/alerts` | Admin |
+| `POST` | `/api/admin/feedback/curate` | Admin (`create` \| `update` \| `unfeature`) |
+
+Public featured responses omit internal IDs / anon hashes / `sourceSubmissionId`.
+
+---
+
+## 4. Commit scope (authoritative file list)
+
+**Only the following paths belong in the commit.** Everything else in the working tree is out of scope.
+
+### 4.1 New (untracked)
+
+```
+app/lib/feedback/types.ts
+app/lib/feedback/templates.ts
+app/lib/feedback/scrub.ts
+app/lib/feedback/eligibility.ts
+app/lib/feedback/devForce.ts
+app/components/feedback/FeedbackModal.tsx
+app/components/feedback/SentimentScale.tsx
+app/components/landing/VerifiedReceiptsSection.tsx
+app/api/feedback/submit/route.ts
+app/api/feedback/featured/route.ts
+app/api/admin/feedback/submissions/route.ts
+app/api/admin/feedback/alerts/route.ts
+app/api/admin/feedback/curate/route.ts
+docs/command/feedback-substrate-prod-readiness-2026-07-16.md
+docs/command/internal-feedback-system-report-2026-07-16.md   # this file
+```
+
+### 4.2 Modified (existing)
+
+```
+.env.example                                   # document FEEDBACK_* vars only
+app/dashboard/page.tsx                         # visit gate + FeedbackModal
+app/admin/analytics/page.tsx                   # Feedback Substrate CMS section
+app/landing/ControlLandingPage.tsx             # VerifiedReceiptsSection
+app/landing/RetailLandingPage.tsx              # VerifiedReceiptsSection
+app/open/_components/OpenLandingClient.tsx     # VerifiedReceiptsSection
+app/components/landing/RetailTrustSection.tsx  # spacing adjacent to receipts
+firebase/firestore.rules                       # four feedback collections
+lib/stack-reveal/resend.ts                     # sendFeedbackP0AlertEmail
+```
+
+### 4.3 Already committed (do not re-add as “new work”)
+
+```
+docs/command/feedback-substrate-spec-2026-06-16.md   # locked at 34ae50c3
+```
+
+### 4.4 Explicitly excluded from this commit
+
+- `app/landing/page.tsx`, `app/open/page.tsx` — appear dirty but **no substantive diff** (line-ending noise only)
+- Seed / pitch / outreach docs and decks  
+- Marketing assets, videos, tmp frames, audit JSON dumps  
+- Unrelated `package.json` / plate manifest / `canonical-claims` / other dirty files (not required by feedback)
+- Local secrets (`.env.local`, `.env.development.local`) — never commit  
+- Prod env configuration, Vercel settings, Firestore rules *deploy* — ops after commit, not this commit
+
+---
+
+## 5. Environment variables (code contract only)
+
+Documented in `.env.example`. **Setting them in Vercel is an ops step after commit — not part of this report’s commit.**
+
+| Variable | Role |
+|----------|------|
+| `FEEDBACK_ENGINEERING_EMAIL` | **Must be `ai@pocketportfolio.app`** — sole operational P0 inbox |
+| `FEEDBACK_ALERT_FROM` | Default From = `ai@pocketportfolio.app`; override only if Resend requires a display-name variant on the same domain |
+| `FEEDBACK_ANON_PEPPER` | HMAC pepper; falls back to `ENCRYPTION_SECRET` (prod: set distinct) |
+| `FEEDBACK_P0_WEBHOOK_URL` | Optional Slack/Discord |
+| `NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS` | Local/dev only; **OMIT in Vercel production** |
+
+---
+
+## 6. Security & GRC posture (as built)
+
+- Client-only eligibility tracking (no visit stream to servers).
+- Dual scrub before network/persistence.
+- Dual-store split: vault text vs analytics metadata.
+- Server-only Firestore writes (Admin SDK); client rules deny writes.
+- `featuredReceipts` public-read of curated excerpts only.
+- Promote = **publish excerpt**, not delete vault (audit retained).
+- Dev force emails gated off in production.
+
+---
+
+## 7. Verification (engineering)
+
+| Check | Result |
+|-------|--------|
+| `npm run lint` | Pass |
+| `npm run typecheck` | Pass |
+| `npm run build` | Pass (exit 0) |
+| Local smoke | Modal → submit → admin queue → promote → landing render |
+
+---
+
+## 8. Holding position
+
+| Action | Status |
+|--------|--------|
+| Implementation | Complete |
+| Documentation (this report) | Complete |
+| Operational email lock | **`ai@pocketportfolio.app` only** |
+| Commit | Authorized by Command — Phase 1 surgical commit |
+| Push / PR | Await Eng after commit |
+| Prod env / Firestore rules deploy / Resend ops | Phases 2–4 — separate from this commit |
+
+---
+
+*When authorized: commit only §4 paths, then push/PR. Do not include operational configuration or unrelated workspace changes.*

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -171,6 +171,31 @@ service cloud.firestore {
       allow write: if false; // Only server can write via Admin SDK
     }
 
+    // Feedback substrate:
+    // - feedbackSubmissions: admin vault (scrubbed text), server-only writes
+    // - feedbackEvents: analytics metadata only, server-only writes
+    // - featuredReceipts: public receipts index (curated), server-only writes but public reads allowed
+    // - feedbackAlertDeliveries: P0 alert delivery log, server-only writes
+    match /feedbackSubmissions/{id} {
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
+    match /feedbackEvents/{id} {
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
+    match /featuredReceipts/{id} {
+      allow read: if true;
+      allow write: if false;
+    }
+
+    match /feedbackAlertDeliveries/{id} {
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
     // Cron email blast aggregates (Admin SDK writes; optional admin read in console / future UI)
     match /adminStats/{docId} {
       allow read: if isAdmin();

--- a/lib/stack-reveal/resend.ts
+++ b/lib/stack-reveal/resend.ts
@@ -123,6 +123,26 @@ export async function sendSupportEmail(
   return { id: data?.id };
 }
 
+/** Feedback P0 alerts: send to engineering inbox with scrubbed excerpt. */
+export async function sendFeedbackP0AlertEmail(params: {
+  to: string | string[];
+  subject: string;
+  html: string;
+  replyTo?: string;
+}): Promise<{ id?: string; error?: string }> {
+  const payload: Record<string, unknown> = {
+    from: process.env.FEEDBACK_ALERT_FROM?.trim() || 'Pocket Portfolio Alerts <ai@pocketportfolio.app>',
+    to: params.to,
+    subject: params.subject,
+    html: params.html,
+    tags: [{ name: 'campaign', value: 'feedback_p0' }],
+  };
+  if (params.replyTo) payload.replyTo = params.replyTo;
+  const { data, error } = await getStackRevealResend().emails.send(payload as any);
+  if (error) return { error: error.message };
+  return { id: data?.id };
+}
+
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, '&amp;')


### PR DESCRIPTION
## Summary
- Implements Internal Feedback System end-to-end (dashboard capture → dual-store → P0 alerts → admin CMS → Pocket/Open verified receipts)
- Spec reference: `docs/command/feedback-substrate-spec-2026-06-16.md` (34ae50c3)
- Operational inbox locked to `ai@pocketportfolio.app` only

## Test plan
- [ ] Vercel prod env: FEEDBACK_ENGINEERING_EMAIL, FEEDBACK_ANON_PEPPER, FEEDBACK_ALERT_FROM; omit NEXT_PUBLIC_FEEDBACK_DEV_FORCE_EMAILS
- [ ] Deploy Firestore rules for feedback collections
- [ ] Smoke: submit via `?showFeedbackModal=true`, verify P0 email, admin queue, promote to landings
