### PR TITLE
fix: Firebase Admin init order for feedback admin CMS

### DIFF
--- a/app/api/admin/feedback/alerts/route.ts
+++ b/app/api/admin/feedback/alerts/route.ts
@@ -22,6 +22,7 @@ function getDb() {
 }
 
 async function requireAdmin(request: NextRequest): Promise<void> {
+  getDb(); // must init Admin SDK before getAuth()
   const authHeader = request.headers.get('authorization');
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
   if (!token) throw Object.assign(new Error('Unauthorized'), { status: 401 });

--- a/app/api/admin/feedback/curate/route.ts
+++ b/app/api/admin/feedback/curate/route.ts
@@ -22,6 +22,7 @@ function getDb() {
 }
 
 async function requireAdmin(request: NextRequest): Promise<{ uid: string; email?: string }> {
+  getDb(); // must init Admin SDK before getAuth()
   const authHeader = request.headers.get('authorization');
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
   if (!token) throw Object.assign(new Error('Unauthorized'), { status: 401 });

--- a/app/api/admin/feedback/submissions/route.ts
+++ b/app/api/admin/feedback/submissions/route.ts
@@ -22,6 +22,7 @@ function getDb() {
 }
 
 async function requireAdmin(request: NextRequest): Promise<void> {
+  getDb(); // must init Admin SDK before getAuth()
   const authHeader = request.headers.get('authorization');
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
   if (!token) throw Object.assign(new Error('Unauthorized'), { status: 401 });

--- a/app/api/feedback/submit/route.ts
+++ b/app/api/feedback/submit/route.ts
@@ -117,6 +117,7 @@ export async function POST(request: NextRequest) {
     const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
     if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+    getDb(); // must init Admin SDK before getAuth()
     const decoded = await getAuth().verifyIdToken(token);
     const uid = decoded.uid;
     const email = (decoded as { email?: string }).email ?? null;


### PR DESCRIPTION
## Summary
- Admin feedback APIs called `getAuth()` before `initializeApp()`, causing production CMS to show "default Firebase app does not exist" and empty queues.
- Init via `getDb()` first in submissions/alerts/curate/submit routes (same pattern as `/api/admin/analytics`).

## Test plan
- [ ] `/admin/analytics` Feedback Substrate loads submissions/alerts/featured without red error
- [ ] Metrics non-zero after prior smoke data
