### PR TITLE
Close bot monetization gaps on symbol farm and data APIs

### DIFF
--- a/app/api/dividend/[ticker]/route.ts
+++ b/app/api/dividend/[ticker]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { enforceDataApiGate } from '@/app/lib/server/data-api-gate';
 import { logDividendDebug, redactUrlForLog } from '@/app/lib/server/safe-log';
 
 // Module loaded - log only in development to avoid production issues
@@ -912,6 +913,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ ticker: string }> }
 ) {
+  const gate = await enforceDataApiGate(request);
+  if (!gate.allowed) return gate.response;
+
   // Route handler entry - log immediately for production visibility
   // Next.js 15: params is always a Promise
   const resolvedParams = await params;

--- a/app/api/dividend/route.ts
+++ b/app/api/dividend/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { enforceDataApiGate } from '@/app/lib/server/data-api-gate';
 import { logDividendDebug, redactUrlForLog } from '@/app/lib/server/safe-log';
 import { sanitizeTickerForUrl } from '@/app/lib/utils/sanitizeTicker';
 
@@ -814,6 +815,9 @@ async function fetchFromYahooFinanceHTML(ticker: string): Promise<DividendData |
 }
 
 export async function GET(request: NextRequest) {
+  const gate = await enforceDataApiGate(request);
+  if (!gate.allowed) return gate.response;
+
   // Get ticker from query parameter instead of path segment
   const { searchParams } = new URL(request.url);
   const tickerParam = searchParams.get('ticker');

--- a/app/api/price/[ticker]/route.ts
+++ b/app/api/price/[ticker]/route.ts
@@ -1,76 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { enforceDataApiGate } from '@/app/lib/server/data-api-gate';
 
 export const dynamic = 'force-dynamic';
-export const dynamicParams = true; // Explicitly allow dynamic params
-export const runtime = 'nodejs'; // Explicitly set runtime for Vercel
-export const revalidate = 0; // Force no caching - ensure fresh data
-
-// Rate limiting storage (in production, use Redis or Vercel KV)
-const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-
-// Free tier: 20 calls per hour per IP
-const FREE_TIER_LIMIT = 20;
-const FREE_TIER_WINDOW = 60 * 60 * 1000; // 1 hour in milliseconds
-
-// Demo key (free community key)
-const DEMO_KEY = 'demo_key';
+export const dynamicParams = true;
+export const runtime = 'nodejs';
+export const revalidate = 0;
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ ticker: string }> }
+  { params }: { params: Promise<{ ticker: string }> },
 ) {
-  // Next.js 15: params is always a Promise
+  const gate = await enforceDataApiGate(request);
+  if (!gate.allowed) return gate.response;
+
   const resolvedParams = await params;
   const ticker = resolvedParams.ticker.toUpperCase();
-  const apiKey = request.nextUrl.searchParams.get('key') || DEMO_KEY;
-  
-  // Get client IP for rate limiting
-  const ip = request.headers.get('x-forwarded-for')?.split(',')[0] || 
-             request.headers.get('x-real-ip') || 
-             'unknown';
-  
-  // Rate limiting for free tier
-  if (apiKey === DEMO_KEY) {
-    const now = Date.now();
-    const key = `free:${ip}`;
-    const limit = rateLimitMap.get(key);
-    
-    if (limit) {
-      // Check if window has expired
-      if (now > limit.resetTime) {
-        // Reset counter
-        rateLimitMap.set(key, { count: 1, resetTime: now + FREE_TIER_WINDOW });
-      } else {
-        // Check if limit exceeded
-        if (limit.count >= FREE_TIER_LIMIT) {
-          return NextResponse.json(
-            { 
-              error: 'Too Many Requests',
-              message: 'Rate limit exceeded. Upgrade to Developer Utility for unlimited API access.',
-              checkout_url: 'https://www.pocketportfolio.app/sponsor?tier=developer-utility&utm_source=api_rate_limit&utm_medium=429&utm_campaign=price_api',
-              limit: FREE_TIER_LIMIT,
-              window: '1 hour'
-            },
-            { status: 429 }
-          );
-        }
-        // Increment counter
-        limit.count++;
-        rateLimitMap.set(key, limit);
-      }
-    } else {
-      // First request from this IP
-      rateLimitMap.set(key, { count: 1, resetTime: now + FREE_TIER_WINDOW });
-    }
-  }
-  
-  // Validate paid API keys against database
-  if (apiKey !== DEMO_KEY) {
+  const apiKey = request.nextUrl.searchParams.get('key') || 'demo_key';
+
+  if (apiKey !== 'demo_key') {
     try {
       const { getFirestore } = await import('firebase-admin/firestore');
       const { initializeApp, getApps, cert } = await import('firebase-admin/app');
-      
-      // Initialize Firebase Admin if not already done
+
       if (!getApps().length) {
         try {
           initializeApp({
@@ -84,91 +35,66 @@ export async function GET(
           console.error('Firebase Admin initialization error:', error);
         }
       }
-      
+
       const db = getFirestore();
-      const apiKeySnapshot = await db.collection('apiKeysByEmail')
+      const apiKeySnapshot = await db
+        .collection('apiKeysByEmail')
         .where('apiKey', '==', apiKey)
         .limit(1)
         .get();
-      
+
       if (apiKeySnapshot.empty) {
-        return NextResponse.json(
-          { error: 'Invalid API key' },
-          { status: 401 }
-        );
+        return NextResponse.json({ error: 'Invalid API key' }, { status: 401 });
       }
-      
-      // Valid paid key - unlimited access
     } catch (error) {
       console.error('API key validation error:', error);
-      // Fallback: allow if key format is valid (pp_ prefix)
       if (!apiKey.startsWith('pp_')) {
-        return NextResponse.json(
-          { error: 'Invalid API key format' },
-          { status: 401 }
-        );
+        return NextResponse.json({ error: 'Invalid API key format' }, { status: 401 });
       }
     }
   }
-  
+
   try {
-    // Fetch price from a free stock API (Yahoo Finance, Alpha Vantage, etc.)
-    // For now, we'll use a mock response. In production, integrate with a real API.
     const price = await fetchStockPrice(ticker);
-    
+
     if (!price) {
       return NextResponse.json(
         { error: `Price not found for ticker: ${ticker}` },
-        { status: 404 }
+        { status: 404 },
       );
     }
-    
-    // Return CSV format for IMPORTDATA compatibility
+
     return new NextResponse(price.toString(), {
       status: 200,
       headers: {
         'Content-Type': 'text/plain',
-        'Cache-Control': 'public, max-age=60', // Cache for 1 minute
+        'Cache-Control': 'public, max-age=60',
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Price fetch error:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch stock price' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch stock price' }, { status: 500 });
   }
 }
 
-/**
- * Fetch stock price from external API
- * TODO: Integrate with real stock price API (Yahoo Finance, Alpha Vantage, etc.)
- */
 async function fetchStockPrice(ticker: string): Promise<number | null> {
   try {
-    // Mock implementation - replace with real API call
-    // Example: Yahoo Finance API, Alpha Vantage, or your own data source
     const response = await fetch(
       `https://query1.finance.yahoo.com/v8/finance/chart/${ticker}?interval=1d&range=1d`,
       {
         headers: {
           'User-Agent': 'Mozilla/5.0',
         },
-      }
+      },
     );
-    
-    if (!response.ok) {
-      return null;
-    }
-    
+
+    if (!response.ok) return null;
+
     const data = await response.json();
     const price = data?.chart?.result?.[0]?.meta?.regularMarketPrice;
-    
     return price || null;
   } catch (error) {
     console.error('Yahoo Finance API error:', error);
-    // Fallback: return null (will show error to user)
     return null;
   }
 }
-

--- a/app/api/quote/route.ts
+++ b/app/api/quote/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { enforceDataApiGate } from '@/app/lib/server/data-api-gate';
 // Rate limiting temporarily disabled for production compatibility
 // import { take } from '@/src/lib/ratelimit/memory';
 
@@ -223,10 +224,8 @@ async function stooqTwo(sym: string) {
 }
 
 export async function GET(request: NextRequest) {
-  // Rate limiting disabled for production compatibility
-  // const ip = request.headers.get('x-forwarded-for') ?? 'local';
-  // const { allowed, remaining, resetAt } = take(`quote:${ip}`, 100, 60_000);
-  // if (!allowed) { return 429 response }
+  const gate = await enforceDataApiGate(request);
+  if (!gate.allowed) return gate.response;
 
   try {
     const { searchParams } = new URL(request.url);

--- a/app/api/tickers/[...ticker]/route.ts
+++ b/app/api/tickers/[...ticker]/route.ts
@@ -9,19 +9,13 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getTickerMetadata } from '@/app/lib/pseo/data';
-import { kv } from '@vercel/kv';
 import {
   DEVELOPER_UTILITY_CHECKOUT_URL,
-  isFirstPartyTickerRequest,
-  isLikelyAutomatedClient,
-  isLikelyDatacenterRequest,
   rateLimitExceededCsvBody,
-  rateLimitExceededJsonBody,
-  resolveTickerClientIp,
   tickerApiBaseHeaders,
   unauthorizedCsvBody,
-  unauthorizedJsonBody,
 } from '@/app/lib/server/ticker-api-gate';
+import { enforceDataApiGate } from '@/app/lib/server/data-api-gate';
 
 export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
@@ -33,12 +27,6 @@ export const maxDuration = 60;
 
 /** Upstream Yahoo chart/quote fetches — fail fast before serverless wall clock kills the invocation */
 const YAHOO_FETCH_TIMEOUT_MS = 14_000;
-
-// Free tier: 50 calls per hour per IP for unauthenticated external traffic
-const FREE_TIER_LIMIT = 50;
-const FREE_TIER_WINDOW_SECONDS = 3600; // 1 hour in seconds (for KV TTL)
-/** Datacenter ASN clients get a tighter free bucket (challenge posture, not hard ban). */
-const DATACENTER_FREE_TIER_LIMIT = 15;
 
 // Cache for historical data (1 hour TTL)
 // Limit cache size to prevent memory leaks in serverless functions
@@ -319,57 +307,6 @@ async function fetchHistoricalData(ticker: string, range: string = '1y'): Promis
   }
 }
 
-/**
- * Distributed rate limiting using Vercel KV (Upstash Redis)
- * Returns: { allowed: boolean, remaining: number, resetTime: number, limit: number }
- */
-async function checkRateLimit(
-  ip: string,
-  limit: number = FREE_TIER_LIMIT
-): Promise<{ allowed: boolean; remaining: number; resetTime: number; limit: number }> {
-  const key = `ratelimit:tickers:free:${ip}:${limit}`;
-  const now = Math.floor(Date.now() / 1000);
-  const resetTime = now + FREE_TIER_WINDOW_SECONDS;
-
-  try {
-    const currentCount = (await kv.get<number>(key)) || 0;
-
-    if (currentCount >= limit) {
-      const ttl = await kv.ttl(key);
-      const actualResetTime = ttl > 0 ? now + ttl : resetTime;
-      return {
-        allowed: false,
-        remaining: 0,
-        resetTime: actualResetTime,
-        limit,
-      };
-    }
-
-    const newCount = currentCount + 1;
-
-    if (currentCount === 0) {
-      await kv.set(key, newCount, { ex: FREE_TIER_WINDOW_SECONDS });
-    } else {
-      await kv.set(key, newCount);
-    }
-
-    return {
-      allowed: true,
-      remaining: limit - newCount,
-      resetTime,
-      limit,
-    };
-  } catch (error) {
-    console.error('[RATE_LIMIT_ERROR] KV operation failed:', error);
-    return {
-      allowed: true,
-      remaining: limit - 1,
-      resetTime,
-      limit,
-    };
-  }
-}
-
 function withTickerHeaders(
   headers: Record<string, string> = {}
 ): Record<string, string> {
@@ -482,134 +419,24 @@ export async function GET(
     );
   }
   
-  // API key: ?key=... or Authorization: Bearer ...
-  const authHeader = request.headers.get('authorization') || '';
-  const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
-  const apiKey =
-    request.nextUrl.searchParams.get('key') ||
-    (bearerMatch?.[1]?.trim() || null);
-  const DEMO_KEY = 'demo_key';
-
-  const ip = resolveTickerClientIp(request);
-  const isFirstParty = isFirstPartyTickerRequest(request);
-  const isAutomated = isLikelyAutomatedClient(request);
-  const isDatacenter = isLikelyDatacenterRequest(request);
-  const isDevelopment = process.env.NODE_ENV === 'development';
-
-  // Check if user has a valid paid API key (bypasses rate limiting)
-  // Developer Utility / Founders Club / Corporate keys live in apiKeysByEmail
-  let hasValidApiKey = false;
-  if (apiKey && apiKey !== DEMO_KEY) {
-    try {
-      const { getFirestore } = await import('firebase-admin/firestore');
-      const { initializeApp, getApps, cert } = await import('firebase-admin/app');
-
-      if (!getApps().length) {
-        try {
-          initializeApp({
-            credential: cert({
-              projectId: process.env.FIREBASE_PROJECT_ID,
-              clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-              privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
-            }),
-          });
-        } catch (error) {
-          console.error('Firebase Admin initialization error:', error);
-        }
-      }
-
-      const db = getFirestore();
-      const apiKeySnapshot = await db
-        .collection('apiKeysByEmail')
-        .where('apiKey', '==', apiKey)
-        .limit(1)
-        .get();
-
-      hasValidApiKey = !apiKeySnapshot.empty;
-    } catch (error) {
-      console.error('API key validation error:', error);
-      // Do NOT fail-open on pp_ prefix — treat as unauthenticated + meter
-      hasValidApiKey = false;
-    }
-  }
-
-  let rateLimitResult: {
-    allowed: boolean;
-    remaining: number;
-    resetTime: number;
-    limit: number;
-  } | null = null;
-
-  // Phase 2: automated external clients without a key → hard 401 (no free firehose)
-  if (!hasValidApiKey && !isFirstParty && !isDevelopment && isAutomated) {
+  // Bot gate: automated → 401; symbol-farm referrers → tight KV bucket; trusted app UI exempt
+  const gate = await enforceDataApiGate(request);
+  if (!gate.allowed) {
+    const status = gate.response.status;
     if (format === 'csv') {
-      return new NextResponse(unauthorizedCsvBody(), {
-        status: 401,
-        headers: withTickerHeaders({
-          'Content-Type': 'text/csv; charset=utf-8',
-          'Content-Disposition': `attachment; filename="${ticker}-api-key-required.csv"`,
-        }),
-      });
-    }
-    return NextResponse.json(unauthorizedJsonBody(), {
-      status: 401,
-      headers: withTickerHeaders(),
-    });
-  }
-
-  // Soft meter: all external unauthenticated formats (JSON + CSV). No desktop/csv/source bypasses.
-  // First-party UI (dashboard, symbol pages, SSR with secret) is exempt.
-  if (!hasValidApiKey && !isFirstParty && !isDevelopment) {
-    const limit = isDatacenter ? DATACENTER_FREE_TIER_LIMIT : FREE_TIER_LIMIT;
-    rateLimitResult = await checkRateLimit(ip, limit);
-
-    if (!rateLimitResult.allowed) {
-      const retryAfter = Math.max(
-        0,
-        rateLimitResult.resetTime - Math.floor(Date.now() / 1000)
-      );
-      // Phase 2 end-state on breach: 401 for machines; keep 429 body shape with checkout for clarity
-      const status = isAutomated ? 401 : 429;
-      const jsonBody = isAutomated
-        ? unauthorizedJsonBody()
-        : {
-            ...rateLimitExceededJsonBody(),
-            limit: rateLimitResult.limit,
-            window: '1 hour',
-            retryAfter,
-          };
-      const csvBody = isAutomated
-        ? unauthorizedCsvBody()
-        : rateLimitExceededCsvBody(retryAfter);
-
-      if (format === 'csv') {
-        return new NextResponse(csvBody, {
-          status,
-          headers: withTickerHeaders({
-            'Content-Type': 'text/csv; charset=utf-8',
-            'Content-Disposition': `attachment; filename="${ticker}-rate-limit-error.csv"`,
-            'X-RateLimit-Limit': String(rateLimitResult.limit),
-            'X-RateLimit-Remaining': '0',
-            'X-RateLimit-Reset': new Date(
-              rateLimitResult.resetTime * 1000
-            ).toISOString(),
-            'Retry-After': String(retryAfter),
-          }),
-        });
-      }
-
-      return NextResponse.json(jsonBody, {
+      const retryAfter = Number(gate.response.headers.get('Retry-After') || '3600');
+      const body =
+        status === 401 ? unauthorizedCsvBody() : rateLimitExceededCsvBody(retryAfter);
+      return new NextResponse(body, {
         status,
         headers: withTickerHeaders({
-          'X-RateLimit-Limit': String(rateLimitResult.limit),
-          'X-RateLimit-Remaining': '0',
-          'X-RateLimit-Reset': new Date(
-            rateLimitResult.resetTime * 1000
-          ).toISOString(),
-          'Retry-After': String(retryAfter),
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${ticker}-api-gate.csv"`,
+          ...(status === 429 ? { 'Retry-After': String(retryAfter) } : {}),
         }),
       });
     }
+    return gate.response;
   }
 
   // Get optional query parameters (searchParams already defined above)
@@ -639,13 +466,9 @@ export async function GET(
           'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
           'X-Data-Status': 'no-data',
         });
-        if (hasValidApiKey) {
+        if (gate.hasValidApiKey) {
           headers['X-RateLimit-Limit'] = 'unlimited';
           headers['X-RateLimit-Remaining'] = 'unlimited';
-        } else if (rateLimitResult) {
-          headers['X-RateLimit-Limit'] = String(rateLimitResult.limit);
-          headers['X-RateLimit-Remaining'] = String(rateLimitResult.remaining);
-          headers['X-RateLimit-Reset'] = new Date(rateLimitResult.resetTime * 1000).toISOString();
         }
         return new NextResponse(csvContent, { status: 200, headers });
       }
@@ -668,13 +491,9 @@ export async function GET(
         'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
         'X-Data-Status': 'no-data',
       });
-      if (hasValidApiKey) {
+      if (gate.hasValidApiKey) {
         headers['X-RateLimit-Limit'] = 'unlimited';
         headers['X-RateLimit-Remaining'] = 'unlimited';
-      } else if (rateLimitResult) {
-        headers['X-RateLimit-Limit'] = String(rateLimitResult.limit);
-        headers['X-RateLimit-Remaining'] = String(rateLimitResult.remaining);
-        headers['X-RateLimit-Reset'] = new Date(rateLimitResult.resetTime * 1000).toISOString();
       }
       return NextResponse.json(emptyResponse, { status: 200, headers });
     }
@@ -691,13 +510,9 @@ export async function GET(
         'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       });
       
-      if (hasValidApiKey) {
+      if (gate.hasValidApiKey) {
         headers['X-RateLimit-Limit'] = 'unlimited';
         headers['X-RateLimit-Remaining'] = 'unlimited';
-      } else if (rateLimitResult) {
-        headers['X-RateLimit-Limit'] = String(rateLimitResult.limit);
-        headers['X-RateLimit-Remaining'] = String(rateLimitResult.remaining);
-        headers['X-RateLimit-Reset'] = new Date(rateLimitResult.resetTime * 1000).toISOString();
       }
       
       return new NextResponse(csv, { headers });
@@ -722,13 +537,9 @@ export async function GET(
       'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
     });
     
-    if (hasValidApiKey) {
+    if (gate.hasValidApiKey) {
       headers['X-RateLimit-Limit'] = 'unlimited';
       headers['X-RateLimit-Remaining'] = 'unlimited';
-    } else if (rateLimitResult) {
-      headers['X-RateLimit-Limit'] = String(rateLimitResult.limit);
-      headers['X-RateLimit-Remaining'] = String(rateLimitResult.remaining);
-      headers['X-RateLimit-Reset'] = new Date(rateLimitResult.resetTime * 1000).toISOString();
     }
     
     return NextResponse.json(response, { headers });

--- a/app/lib/server/data-api-gate.ts
+++ b/app/lib/server/data-api-gate.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { kv } from '@vercel/kv';
+import {
+  DEVELOPER_UTILITY_CHECKOUT_URL,
+  extractApiKeyFromRequest,
+  isFirstPartyTickerRequest,
+  isLikelyAutomatedClient,
+  isLikelyDatacenterRequest,
+  isSymbolFarmReferrer,
+  resolveBotGateClientIp,
+} from '@/lib/bot-gate';
+import {
+  rateLimitExceededJsonBody,
+  tickerApiBaseHeaders,
+  unauthorizedJsonBody,
+} from '@/app/lib/server/ticker-api-gate';
+
+const DEMO_KEY = 'demo_key';
+const WINDOW_SECONDS = 3600;
+const FREE_TIER_LIMIT = 50;
+const DATACENTER_LIMIT = 12;
+const SYMBOL_FARM_LIMIT = 6;
+
+export type DataApiGateResult =
+  | { allowed: true; hasValidApiKey: boolean }
+  | { allowed: false; response: NextResponse };
+
+async function validatePaidApiKey(apiKey: string): Promise<boolean> {
+  if (!apiKey || apiKey === DEMO_KEY) return false;
+  try {
+    const { getFirestore } = await import('firebase-admin/firestore');
+    const { initializeApp, getApps, cert } = await import('firebase-admin/app');
+
+    if (!getApps().length) {
+      try {
+        initializeApp({
+          credential: cert({
+            projectId: process.env.FIREBASE_PROJECT_ID,
+            clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+            privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+          }),
+        });
+      } catch (error) {
+        console.error('Firebase Admin initialization error:', error);
+      }
+    }
+
+    const db = getFirestore();
+    const snap = await db
+      .collection('apiKeysByEmail')
+      .where('apiKey', '==', apiKey)
+      .limit(1)
+      .get();
+    return !snap.empty;
+  } catch (error) {
+    console.error('API key validation error:', error);
+    return false;
+  }
+}
+
+async function checkKvRateLimit(
+  ip: string,
+  bucket: string,
+  limit: number,
+): Promise<{ allowed: boolean; retryAfter: number }> {
+  const key = `ratelimit:data-api:${bucket}:${ip}:${limit}`;
+  const now = Math.floor(Date.now() / 1000);
+
+  try {
+    const current = (await kv.get<number>(key)) || 0;
+    if (current >= limit) {
+      const ttl = await kv.ttl(key);
+      return { allowed: false, retryAfter: ttl > 0 ? ttl : WINDOW_SECONDS };
+    }
+    const next = current + 1;
+    if (current === 0) {
+      await kv.set(key, next, { ex: WINDOW_SECONDS });
+    } else {
+      await kv.set(key, next);
+    }
+    return { allowed: true, retryAfter: 0 };
+  } catch (error) {
+    console.error('[data-api-gate] KV rate limit failed:', error);
+    return { allowed: true, retryAfter: 0 };
+  }
+}
+
+function gateHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return { ...tickerApiBaseHeaders(), ...extra };
+}
+
+function unauthorizedResponse(): NextResponse {
+  return NextResponse.json(unauthorizedJsonBody(), {
+    status: 401,
+    headers: gateHeaders(),
+  });
+}
+
+function rateLimitedResponse(retryAfter: number): NextResponse {
+  return NextResponse.json(
+    {
+      ...rateLimitExceededJsonBody(),
+      retryAfter,
+    },
+    {
+      status: 429,
+      headers: gateHeaders({
+        'Retry-After': String(Math.max(1, retryAfter)),
+      }),
+    },
+  );
+}
+
+/**
+ * Enforce paid-key / rate-limit policy on market data APIs.
+ * Automated clients always need a key. Symbol-farm referrers get a tight bucket.
+ */
+export async function enforceDataApiGate(
+  request: NextRequest,
+): Promise<DataApiGateResult> {
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  if (isDevelopment) return { allowed: true, hasValidApiKey: false };
+
+  const apiKey = extractApiKeyFromRequest(request);
+  const hasValidApiKey = apiKey ? await validatePaidApiKey(apiKey) : false;
+  if (hasValidApiKey) return { allowed: true, hasValidApiKey: true };
+
+  const isAutomated = isLikelyAutomatedClient(request);
+  const isFirstParty = isFirstPartyTickerRequest(request);
+
+  if (isAutomated) {
+    return { allowed: false, response: unauthorizedResponse() };
+  }
+
+  if (isFirstParty) {
+    return { allowed: true, hasValidApiKey: false };
+  }
+
+  const ip = resolveBotGateClientIp(request);
+  const isDatacenter = isLikelyDatacenterRequest(request);
+  const fromSymbolFarm = isSymbolFarmReferrer(request);
+  const limit = fromSymbolFarm
+    ? SYMBOL_FARM_LIMIT
+    : isDatacenter
+      ? DATACENTER_LIMIT
+      : FREE_TIER_LIMIT;
+  const bucket = fromSymbolFarm ? 'symbol-farm' : isDatacenter ? 'dc' : 'external';
+
+  const rate = await checkKvRateLimit(ip, bucket, limit);
+  if (!rate.allowed) {
+    return { allowed: false, response: rateLimitedResponse(rate.retryAfter) };
+  }
+
+  return { allowed: true, hasValidApiKey: false };
+}
+
+export { DEVELOPER_UTILITY_CHECKOUT_URL };

--- a/app/lib/server/ticker-api-gate.ts
+++ b/app/lib/server/ticker-api-gate.ts
@@ -1,19 +1,22 @@
 import type { NextRequest } from 'next/server';
 import { createHash } from 'crypto';
+import {
+  DEVELOPER_UTILITY_CHECKOUT_URL,
+  FIRST_PARTY_HEADER,
+  resolveBotGateClientIp,
+} from '@/lib/bot-gate';
 
-/** Canonical scraper upsell — Developer Utility (not Code Supporter, not bare /sponsor). */
-export const DEVELOPER_UTILITY_CHECKOUT_URL =
-  'https://www.pocketportfolio.app/sponsor?tier=developer-utility&utm_source=api_rate_limit&utm_medium=429&utm_campaign=ticker_api';
+export {
+  DEVELOPER_UTILITY_CHECKOUT_URL,
+  FIRST_PARTY_HEADER,
+  extractApiKeyFromRequest,
+  isFirstPartyTickerRequest,
+  isLikelyAutomatedClient,
+  isLikelyDatacenterRequest,
+  isSymbolFarmPath,
+} from '@/lib/bot-gate';
 
 export const TICKER_API_ROBOTS_TAG = 'noindex, nofollow';
-
-export const FIRST_PARTY_HEADER = 'x-pp-first-party';
-
-const FIRST_PARTY_HOST_SUFFIXES = [
-  'pocketportfolio.app',
-  'localhost',
-  '127.0.0.1',
-] as const;
 
 function getFirstPartySecret(): string | null {
   const dedicated = process.env.PP_FIRST_PARTY_FETCH_SECRET?.trim();
@@ -33,66 +36,10 @@ export function getFirstPartyFetchHeaders(): Record<string, string> {
   };
 }
 
-function hostFromUrlish(value: string | null): string | null {
-  if (!value) return null;
-  try {
-    if (value.startsWith('http://') || value.startsWith('https://')) {
-      return new URL(value).hostname.toLowerCase();
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-function isFirstPartyHost(hostname: string | null): boolean {
-  if (!hostname) return false;
-  const host = hostname.split(':')[0]?.toLowerCase() ?? '';
-  return FIRST_PARTY_HOST_SUFFIXES.some(
-    (suffix) => host === suffix || host.endsWith(`.${suffix}`)
-  );
-}
-
-/**
- * First-party = browser same-origin/same-site, or SSR with shared secret header.
- * Query flags like ?desktop=true must NEVER grant this.
- */
-export function isFirstPartyTickerRequest(request: NextRequest): boolean {
-  const secret = getFirstPartySecret();
-  const provided = request.headers.get(FIRST_PARTY_HEADER);
-  if (secret && provided && provided === secret) {
-    return true;
-  }
-
-  const secFetchSite = (request.headers.get('sec-fetch-site') || '').toLowerCase();
-  if (secFetchSite === 'same-origin' || secFetchSite === 'same-site') {
-    return true;
-  }
-
-  const originHost = hostFromUrlish(request.headers.get('origin'));
-  if (isFirstPartyHost(originHost)) {
-    return true;
-  }
-
-  const refererHost = hostFromUrlish(request.headers.get('referer'));
-  if (isFirstPartyHost(refererHost)) {
-    return true;
-  }
-
-  return false;
-}
-
-/** Stable client id for rate limiting when IP headers are missing (never use Date.now()). */
+/** Stable client id for rate limiting when IP headers are missing. */
 export function resolveTickerClientIp(request: NextRequest): string {
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  const cfConnectingIp = request.headers.get('cf-connecting-ip');
-  const realIp = request.headers.get('x-real-ip');
-  const ip =
-    forwardedFor?.split(',')[0]?.trim() ||
-    cfConnectingIp?.trim() ||
-    realIp?.trim();
-
-  if (ip) return ip;
+  const ip = resolveBotGateClientIp(request);
+  if (!ip.startsWith('ua-')) return ip;
 
   const ua = request.headers.get('user-agent') || 'unknown';
   const accept = request.headers.get('accept') || '';
@@ -101,75 +48,6 @@ export function resolveTickerClientIp(request: NextRequest): string {
     .digest('hex')
     .slice(0, 24);
   return `ua-${digest}`;
-}
-
-/**
- * Phase 2 hard gate: non-browser extractors without a key.
- * Browser-like clients still receive soft metering.
- */
-export function isLikelyAutomatedClient(request: NextRequest): boolean {
-  const ua = (request.headers.get('user-agent') || '').toLowerCase();
-  if (!ua || ua === 'unknown') return true;
-
-  const botHints = [
-    'curl/',
-    'wget/',
-    'python-requests',
-    'python-urllib',
-    'httpx',
-    'go-http-client',
-    'java/',
-    'okhttp',
-    'scrapy',
-    'aiohttp',
-    'node-fetch',
-    'axios/',
-    'postman',
-    'insomnia',
-    'httpclient',
-    'libwww',
-    'mechanize',
-  ];
-  if (botHints.some((h) => ua.includes(h))) return true;
-
-  const secFetchMode = (request.headers.get('sec-fetch-mode') || '').toLowerCase();
-  const secFetchSite = (request.headers.get('sec-fetch-site') || '').toLowerCase();
-  // Real browsers navigating/fetching same-site usually send Sec-Fetch-*
-  if (!secFetchMode && !secFetchSite && !request.headers.get('origin')) {
-    // Accept headers that look like raw API clients
-    const accept = (request.headers.get('accept') || '').toLowerCase();
-    if (
-      accept.includes('application/json') &&
-      !accept.includes('text/html') &&
-      !ua.includes('mozilla/')
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/** Datacenter / hosting ASN hint via Cloudflare header when present (challenge posture, not hard ban). */
-export function isLikelyDatacenterRequest(request: NextRequest): boolean {
-  const cfAsn = request.headers.get('cf-asn') || '';
-  // Common cloud ASN list — used only to tighten free quota, never hard 403
-  const cloudAsns = new Set([
-    '16509', // Amazon
-    '14618', // Amazon
-    '15169', // Google
-    '396982', // Google Cloud
-    '8075', // Microsoft
-    '14061', // DigitalOcean
-    '20473', // Choopa/Vultr
-    '24940', // Hetzner
-    '16276', // OVH
-    '13335', // Cloudflare (workers sometimes)
-    '63949', // Linode/Akamai
-  ]);
-  if (cfAsn && cloudAsns.has(cfAsn)) return true;
-
-  return false;
 }
 
 export function tickerApiBaseHeaders(): Record<string, string> {
@@ -183,16 +61,17 @@ export function rateLimitExceededJsonBody() {
     error: 'Too Many Requests',
     message:
       'Rate limit exceeded. Upgrade to Developer Utility for unlimited API access.',
-    checkout_url: DEVELOPER_UTILITY_CHECKOUT_URL,
+    checkout_url: `${DEVELOPER_UTILITY_CHECKOUT_URL.split('?')[0]}?tier=developer-utility&utm_source=api_rate_limit&utm_medium=429&utm_campaign=ticker_api`,
   };
 }
 
 export function rateLimitExceededCsvBody(retryAfterSeconds: number): string {
   const minutes = Math.ceil(Math.max(0, retryAfterSeconds) / 60);
   const day = new Date().toISOString().split('T')[0];
+  const checkout = rateLimitExceededJsonBody().checkout_url;
   return [
     'Date,Error,CheckoutUrl,RetryAfter',
-    `${day},"Rate limit exceeded. Upgrade to Developer Utility for unlimited API access.",${DEVELOPER_UTILITY_CHECKOUT_URL},${minutes} minute${minutes !== 1 ? 's' : ''}`,
+    `${day},"Rate limit exceeded. Upgrade to Developer Utility for unlimited API access.",${checkout},${minutes} minute${minutes !== 1 ? 's' : ''}`,
   ].join('\n');
 }
 
@@ -201,14 +80,15 @@ export function unauthorizedJsonBody() {
     error: 'Unauthorized',
     message:
       'Hosted data extraction requires an active Developer Utility (or Founders Club / Corporate) API key.',
-    checkout_url: DEVELOPER_UTILITY_CHECKOUT_URL,
+    checkout_url: `${DEVELOPER_UTILITY_CHECKOUT_URL.split('?')[0]}?tier=developer-utility&utm_source=api_rate_limit&utm_medium=401&utm_campaign=ticker_api`,
   };
 }
 
 export function unauthorizedCsvBody(): string {
   const day = new Date().toISOString().split('T')[0];
+  const checkout = unauthorizedJsonBody().checkout_url;
   return [
     'Date,Error,CheckoutUrl',
-    `${day},"API key required for automated extraction. Upgrade to Developer Utility.",${DEVELOPER_UTILITY_CHECKOUT_URL}`,
+    `${day},"API key required for automated extraction. Upgrade to Developer Utility.",${checkout}`,
   ].join('\n');
 }

--- a/lib/bot-gate-middleware.ts
+++ b/lib/bot-gate-middleware.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { kv } from '@vercel/kv';
+import {
+  botGatePaywallUrl,
+  extractApiKeyFromRequest,
+  isAllowedSearchCrawler,
+  isLikelyAutomatedClient,
+  isMeteredDataApiPath,
+  isSymbolFarmPath,
+  resolveBotGateClientIp,
+  shouldApplyBotGate,
+  wantsJsonResponse,
+} from '@/lib/bot-gate';
+
+const SURFACE_PAGE_LIMIT = 24;
+const SURFACE_WINDOW_SECONDS = 3600;
+
+async function withinSurfacePageBudget(ip: string): Promise<boolean> {
+  const key = `ratelimit:surface:html:${ip}`;
+  try {
+    const count = (await kv.get<number>(key)) || 0;
+    if (count >= SURFACE_PAGE_LIMIT) return false;
+    const next = count + 1;
+    if (count === 0) {
+      await kv.set(key, next, { ex: SURFACE_WINDOW_SECONDS });
+    } else {
+      await kv.set(key, next);
+    }
+    return true;
+  } catch (error) {
+    console.error('[bot-gate-middleware] KV surface limit failed:', error);
+    return true;
+  }
+}
+
+/**
+ * Edge paywall for symbol-farm HTML and automated clients on metered surfaces.
+ * Search crawlers may index HTML; humans get a generous page budget before upsell.
+ */
+export async function applyBotGateMiddleware(
+  request: NextRequest,
+): Promise<NextResponse | null> {
+  const pathname = request.nextUrl.pathname;
+  if (!shouldApplyBotGate(pathname)) return null;
+
+  const apiKey = extractApiKeyFromRequest(request);
+  if (apiKey && apiKey.startsWith('pp_')) {
+    return null;
+  }
+
+  const searchCrawler = isAllowedSearchCrawler(request);
+  const automated = isLikelyAutomatedClient(request);
+
+  if (automated && !searchCrawler) {
+    if (wantsJsonResponse(request) || isMeteredDataApiPath(pathname)) {
+      return NextResponse.json(
+        {
+          error: 'Unauthorized',
+          message:
+            'Automated access requires a Developer Utility API key. Upgrade to continue.',
+          checkout_url: botGatePaywallUrl(request, 'automated_api'),
+        },
+        {
+          status: 401,
+          headers: {
+            'X-Robots-Tag': 'noindex, nofollow',
+            'Cache-Control': 'no-store',
+          },
+        },
+      );
+    }
+
+    return NextResponse.redirect(
+      botGatePaywallUrl(request, 'automated_symbol_farm'),
+      307,
+    );
+  }
+
+  if (isSymbolFarmPath(pathname) && !searchCrawler) {
+    const ip = resolveBotGateClientIp(request);
+    const allowed = await withinSurfacePageBudget(ip);
+    if (!allowed) {
+      return NextResponse.redirect(
+        botGatePaywallUrl(request, 'symbol_farm_rate'),
+        307,
+      );
+    }
+  }
+
+  return null;
+}

--- a/lib/bot-gate.ts
+++ b/lib/bot-gate.ts
@@ -1,0 +1,259 @@
+import type { NextRequest } from 'next/server';
+
+/** Canonical scraper upsell — Developer Utility */
+export const DEVELOPER_UTILITY_CHECKOUT_URL =
+  'https://www.pocketportfolio.app/sponsor?tier=developer-utility&utm_source=bot_gate&utm_medium=401&utm_campaign=data_surface';
+
+export const FIRST_PARTY_HEADER = 'x-pp-first-party';
+
+const FIRST_PARTY_HOST_SUFFIXES = [
+  'pocketportfolio.app',
+  'localhost',
+  '127.0.0.1',
+] as const;
+
+/** App surfaces that may call market data APIs without a paid key (humans in-product). */
+const TRUSTED_APP_PATH_PREFIXES = [
+  '/dashboard',
+  '/import',
+  '/positions',
+  '/watchlist',
+  '/login',
+  '/features',
+  '/tools/risk-calculator',
+  '/tools/track',
+  '/static',
+] as const;
+
+const SEARCH_CRAWLER_HINTS = [
+  'googlebot',
+  'bingbot',
+  'duckduckbot',
+  'yandexbot',
+  'applebot',
+  'facebookexternalhit',
+  'linkedinbot',
+  'twitterbot',
+  'slackbot',
+] as const;
+
+const AUTOMATION_UA_HINTS = [
+  'curl/',
+  'wget/',
+  'python-requests',
+  'python-urllib',
+  'httpx',
+  'go-http-client',
+  'java/',
+  'okhttp',
+  'scrapy',
+  'aiohttp',
+  'node-fetch',
+  'axios/',
+  'postman',
+  'insomnia',
+  'httpclient',
+  'libwww',
+  'mechanize',
+  'headlesschrome',
+  'headless',
+  'puppeteer',
+  'playwright',
+  'selenium',
+  'webdriver',
+  'phantomjs',
+  'slurp',
+  'semrushbot',
+  'ahrefsbot',
+  'petalbot',
+  'bytespider',
+  'gptbot',
+  'claudebot',
+  'anthropic-ai',
+  'ccbot',
+] as const;
+
+export function isSymbolFarmPath(pathname: string): boolean {
+  return pathname === '/s' || pathname.startsWith('/s/');
+}
+
+export function isMeteredDataApiPath(pathname: string): boolean {
+  return (
+    pathname.startsWith('/api/tickers/') ||
+    pathname === '/api/quote' ||
+    pathname.startsWith('/api/price/') ||
+    pathname === '/api/dividend' ||
+    pathname.startsWith('/api/dividend/')
+  );
+}
+
+export function shouldApplyBotGate(pathname: string): boolean {
+  return isSymbolFarmPath(pathname) || isMeteredDataApiPath(pathname);
+}
+
+export function extractApiKeyFromRequest(request: NextRequest): string | null {
+  const authHeader = request.headers.get('authorization') || '';
+  const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  return (
+    request.nextUrl.searchParams.get('key')?.trim() ||
+    bearerMatch?.[1]?.trim() ||
+    null
+  );
+}
+
+function hostFromUrlish(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    if (value.startsWith('http://') || value.startsWith('https://')) {
+      return new URL(value).hostname.toLowerCase();
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function pathFromUrlish(value: string | null): string {
+  if (!value) return '';
+  try {
+    if (value.startsWith('http://') || value.startsWith('https://')) {
+      return new URL(value).pathname;
+    }
+  } catch {
+    return '';
+  }
+  return '';
+}
+
+function isFirstPartyHost(hostname: string | null): boolean {
+  if (!hostname) return false;
+  const host = hostname.split(':')[0]?.toLowerCase() ?? '';
+  return FIRST_PARTY_HOST_SUFFIXES.some(
+    (suffix) => host === suffix || host.endsWith(`.${suffix}`),
+  );
+}
+
+export function refererPath(request: NextRequest): string {
+  return pathFromUrlish(request.headers.get('referer'));
+}
+
+export function isSymbolFarmReferrer(request: NextRequest): boolean {
+  return isSymbolFarmPath(refererPath(request));
+}
+
+export function isTrustedAppReferrer(request: NextRequest): boolean {
+  const path = refererPath(request);
+  if (!path) return false;
+  return TRUSTED_APP_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
+}
+
+function hasFirstPartySecret(request: NextRequest): boolean {
+  const dedicated = process.env.PP_FIRST_PARTY_FETCH_SECRET?.trim();
+  const cron = process.env.CRON_SECRET?.trim();
+  const secret = dedicated || cron;
+  if (!secret) return false;
+  return request.headers.get(FIRST_PARTY_HEADER) === secret;
+}
+
+/**
+ * Trusted in-product browser context (dashboard, import, etc.).
+ * Symbol-farm `/s/*` pages are never first-party for data API metering.
+ */
+export function isFirstPartyTickerRequest(request: NextRequest): boolean {
+  if (hasFirstPartySecret(request)) return true;
+  if (isSymbolFarmReferrer(request)) return false;
+
+  const secFetchSite = (request.headers.get('sec-fetch-site') || '').toLowerCase();
+  const sameSite =
+    secFetchSite === 'same-origin' || secFetchSite === 'same-site';
+
+  const originHost = hostFromUrlish(request.headers.get('origin'));
+  const refererHost = hostFromUrlish(request.headers.get('referer'));
+  const onFirstPartyHost =
+    isFirstPartyHost(originHost) || isFirstPartyHost(refererHost);
+
+  if (!onFirstPartyHost && !sameSite) return false;
+
+  return isTrustedAppReferrer(request);
+}
+
+export function isAllowedSearchCrawler(request: NextRequest): boolean {
+  const ua = (request.headers.get('user-agent') || '').toLowerCase();
+  if (!ua) return false;
+  return SEARCH_CRAWLER_HINTS.some((hint) => ua.includes(hint));
+}
+
+export function isLikelyAutomatedClient(request: NextRequest): boolean {
+  const ua = (request.headers.get('user-agent') || '').toLowerCase();
+  if (!ua || ua === 'unknown') return true;
+
+  if (isAllowedSearchCrawler(request)) return false;
+
+  if (AUTOMATION_UA_HINTS.some((hint) => ua.includes(hint))) return true;
+
+  const secFetchMode = (request.headers.get('sec-fetch-mode') || '').toLowerCase();
+  const secFetchSite = (request.headers.get('sec-fetch-site') || '').toLowerCase();
+  if (!secFetchMode && !secFetchSite && !request.headers.get('origin')) {
+    const accept = (request.headers.get('accept') || '').toLowerCase();
+    if (
+      accept.includes('application/json') &&
+      !accept.includes('text/html') &&
+      !ua.includes('mozilla/')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isLikelyDatacenterRequest(request: NextRequest): boolean {
+  const cfAsn = request.headers.get('cf-asn') || '';
+  const cloudAsns = new Set([
+    '16509',
+    '14618',
+    '15169',
+    '396982',
+    '8075',
+    '14061',
+    '20473',
+    '24940',
+    '16276',
+    '13335',
+    '63949',
+  ]);
+  return Boolean(cfAsn && cloudAsns.has(cfAsn));
+}
+
+export function resolveBotGateClientIp(request: NextRequest): string {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  const cfConnectingIp = request.headers.get('cf-connecting-ip');
+  const realIp = request.headers.get('x-real-ip');
+  const ip =
+    forwardedFor?.split(',')[0]?.trim() ||
+    cfConnectingIp?.trim() ||
+    realIp?.trim();
+  if (ip) return ip;
+
+  const ua = request.headers.get('user-agent') || 'unknown';
+  const accept = request.headers.get('accept') || '';
+  return `ua-${ua.length}-${accept.length}`;
+}
+
+export function botGatePaywallUrl(request: NextRequest, campaign: string): string {
+  const url = new URL(DEVELOPER_UTILITY_CHECKOUT_URL);
+  url.searchParams.set('utm_campaign', campaign);
+  const returnTo = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+  if (returnTo && returnTo !== '/') {
+    url.searchParams.set('returnTo', returnTo);
+  }
+  return url.toString();
+}
+
+export function wantsJsonResponse(request: NextRequest): boolean {
+  const accept = (request.headers.get('accept') || '').toLowerCase();
+  if (accept.includes('application/json')) return true;
+  return isMeteredDataApiPath(request.nextUrl.pathname);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { applyBotGateMiddleware } from '@/lib/bot-gate-middleware';
 import {
   isLocalOpenDevHost,
   isLocalPocketDevHost,
@@ -60,10 +61,21 @@ const OPEN_SPECIAL_FILES: ReadonlySet<string> = new Set([
 /** Middleware rewrite target — page calls notFound() → app/open/not-found.tsx. */
 const OPEN_NOT_FOUND_REWRITE = '/open/__not-a-b2b-route__';
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   // Canonical host: apex → www so referral sessionStorage + cookies stay on one origin (ref survives signup).
   // Lowercase: Host is case-insensitive; mismatched casing must not skip OPEN_HOSTS matching (would mis-route).
   const host = request.headers.get('host')?.split(':')[0]?.toLowerCase() ?? '';
+
+  const isLocalDevPocketHostEarly = isLocalPocketDevHost(host);
+  if (
+    isLocalDevPocketHostEarly ||
+    host === 'www.pocketportfolio.app' ||
+    host === 'pocketportfolio.app'
+  ) {
+    const gateRes = await applyBotGateMiddleware(request);
+    if (gateRes) return gateRes;
+  }
+
   if (host === 'pocketportfolio.app') {
     const url = request.nextUrl.clone();
     url.hostname = 'www.pocketportfolio.app';

--- a/tests/unit/bot-gate.spec.ts
+++ b/tests/unit/bot-gate.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  isFirstPartyTickerRequest,
+  isLikelyAutomatedClient,
+  isSymbolFarmPath,
+  isSymbolFarmReferrer,
+  isTrustedAppReferrer,
+} from '@/lib/bot-gate';
+
+function req(
+  url: string,
+  init?: { headers?: Record<string, string> },
+): NextRequest {
+  return new NextRequest(url, init);
+}
+
+describe('bot-gate', () => {
+  it('detects symbol farm paths', () => {
+    expect(isSymbolFarmPath('/s/spy')).toBe(true);
+    expect(isSymbolFarmPath('/s/spy/json-api')).toBe(true);
+    expect(isSymbolFarmPath('/dashboard')).toBe(false);
+  });
+
+  it('treats symbol-farm referrers as untrusted for first-party API', () => {
+    const request = req('https://www.pocketportfolio.app/api/tickers/spy/json', {
+      headers: {
+        referer: 'https://www.pocketportfolio.app/s/spy/json-api',
+        'sec-fetch-site': 'same-origin',
+      },
+    });
+    expect(isSymbolFarmReferrer(request)).toBe(true);
+    expect(isFirstPartyTickerRequest(request)).toBe(false);
+  });
+
+  it('allows dashboard referrers as first-party', () => {
+    const request = req('https://www.pocketportfolio.app/api/tickers/spy/json', {
+      headers: {
+        referer: 'https://www.pocketportfolio.app/dashboard',
+        'sec-fetch-site': 'same-origin',
+      },
+    });
+    expect(isTrustedAppReferrer(request)).toBe(true);
+    expect(isFirstPartyTickerRequest(request)).toBe(true);
+  });
+
+  it('flags obvious automation user agents', () => {
+    const request = req('https://www.pocketportfolio.app/s/spy', {
+      headers: { 'user-agent': 'python-requests/2.31.0' },
+    });
+    expect(isLikelyAutomatedClient(request)).toBe(true);
+  });
+
+  it('allows verified search crawlers for HTML indexing', () => {
+    const request = req('https://www.pocketportfolio.app/s/spy', {
+      headers: { 'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' },
+    });
+    expect(isLikelyAutomatedClient(request)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared bot gate (`lib/bot-gate.ts`) with stricter automation detection and symbol-farm referrer rules (no first-party API exemption from `/s/*`).
- Enforce paid-key / KV rate limits on tickers, quote, price, and dividend APIs via `enforceDataApiGate`.
- Wire edge middleware paywall: automated clients on `/s/*` redirect to Developer Utility; humans get 24 page views/IP/hour before upsell.

## Test plan
- [ ] `curl -A python-requests/2.31 https://www.pocketportfolio.app/api/tickers/SPY/json` → 401 + checkout_url
- [ ] `curl -A python-requests/2.31 https://www.pocketportfolio.app/s/spy` → 307 to sponsor
- [ ] Browser on `/dashboard` fetching `/api/tickers/SPY/json` → 200 (first-party exempt)
- [ ] Browser on `/s/spy` fetching ticker API → allowed up to 6/hr then 429
- [ ] `npm run lint` + `npm run typecheck` + `npx vitest run tests/unit/bot-gate.spec.ts`