### PR TITLE
Rename nav Utility to Pricing and remove beating heart

### DIFF
--- a/app/components/dashboard/SovereignHeader.tsx
+++ b/app/components/dashboard/SovereignHeader.tsx
@@ -647,7 +647,7 @@ export function SovereignHeader({ syncState = 'idle', lastSyncTime = null, user,
                   e.currentTarget.style.background = 'transparent';
                 }}
               >
-                Developer Utility
+                Pricing
               </Link>
               
               {/* Admin Links - Only show if user is admin */}

--- a/app/components/marketing/ProductionNavbar.tsx
+++ b/app/components/marketing/ProductionNavbar.tsx
@@ -448,8 +448,8 @@ function ProductionNavbarInner() {
                     transition: 'all 0.2s ease'
                   }}
                   onMouseEnter={(e) => {
-                    e.currentTarget.style.borderColor = '#E1306C';
-                    e.currentTarget.style.color = '#E1306C';
+                    e.currentTarget.style.borderColor = 'var(--accent-warm)';
+                    e.currentTarget.style.color = 'var(--accent-warm)';
                     e.currentTarget.style.transform = 'translateY(-1px)';
                   }}
                   onMouseLeave={(e) => {
@@ -458,17 +458,7 @@ function ProductionNavbarInner() {
                     e.currentTarget.style.transform = 'translateY(0)';
                   }}
                 >
-                  <svg 
-                    width="16" 
-                    height="16" 
-                    viewBox="0 0 24 24" 
-                    fill="none" 
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="sponsor-heart"
-                  >
-                    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" fill="#E1306C"/>
-                  </svg>
-                  Utility
+                  Pricing
                 </Link>
                 <ThemeSwitcher />
               </div>
@@ -791,17 +781,7 @@ function ProductionNavbarInner() {
                   fontWeight: '500'
                 }}
               >
-                <svg 
-                  width="16" 
-                  height="16" 
-                  viewBox="0 0 24 24" 
-                  fill="none" 
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="sponsor-heart"
-                >
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" fill="#E1306C"/>
-                </svg>
-                Utility
+                Pricing
               </Link>
               
               <div style={{

--- a/app/components/nav/TabBar.tsx
+++ b/app/components/nav/TabBar.tsx
@@ -9,7 +9,7 @@ import {
   Bookmark,
   FileUp,
   Settings2,
-  HeartHandshake,
+  Tags,
   type LucideIcon,
 } from 'lucide-react';
 import { isOpenPortfolioHost } from '@/lib/surface-host';
@@ -60,10 +60,10 @@ const tabs: TabItem[] = [
   },
   {
     id: 'sponsor',
-    label: 'Utility',
+    label: 'Pricing',
     href: '/sponsor',
-    ariaLabel: 'Developer Utility — support Pocket Portfolio',
-    icon: HeartHandshake,
+    ariaLabel: 'Pricing and sponsorship plans',
+    icon: Tags,
   },
 ];
 

--- a/app/landing/ControlLandingPage.tsx
+++ b/app/landing/ControlLandingPage.tsx
@@ -534,8 +534,8 @@ export default function ControlLandingPage() {
                     transition: 'all 0.2s ease'
                   }}
                   onMouseEnter={(e) => {
-                    e.currentTarget.style.borderColor = '#E1306C';
-                    e.currentTarget.style.color = '#E1306C';
+                    e.currentTarget.style.borderColor = 'var(--accent-warm)';
+                    e.currentTarget.style.color = 'var(--accent-warm)';
                     e.currentTarget.style.transform = 'translateY(-1px)';
                   }}
                   onMouseLeave={(e) => {
@@ -544,17 +544,7 @@ export default function ControlLandingPage() {
                     e.currentTarget.style.transform = 'translateY(0)';
                   }}
                 >
-                  <svg 
-                    width="16" 
-                    height="16" 
-                    viewBox="0 0 24 24" 
-                    fill="none" 
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="sponsor-heart"
-                  >
-                    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" fill="#E1306C"/>
-                  </svg>
-                  Utility
+                  Pricing
                 </a>
                 <ThemeSwitcher />
               </div>

--- a/app/lib/nav/dashboardNavConfig.ts
+++ b/app/lib/nav/dashboardNavConfig.ts
@@ -10,7 +10,7 @@ import {
   BarChart3,
   ShoppingBag,
   LifeBuoy,
-  HeartHandshake,
+  Tags,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -130,9 +130,9 @@ export const DASHBOARD_NAV_SECTIONS: DashboardNavSection[] = [
       },
       {
         id: 'utility',
-        label: 'Developer Utility',
+        label: 'Pricing',
         href: '/sponsor',
-        icon: HeartHandshake,
+        icon: Tags,
       },
     ],
   },
@@ -218,7 +218,7 @@ export const MOBILE_NAV_SSOT_LINKS: ReadonlyArray<{ label: string; href: string 
   { label: 'Live Market Data', href: '/live' },
   { label: 'Tax Converters', href: '/tools' },
   { label: 'JSON API Directory', href: '/s/directory' },
-  { label: 'Developer Utility', href: '/sponsor' },
+  { label: 'Pricing', href: '/sponsor' },
   { label: 'Analytics', href: '/admin/analytics' },
   { label: 'Sales', href: '/admin/sales' },
   { label: 'View support', href: '/admin/support' },

--- a/app/lib/tour/dashboardTourConfig.ts
+++ b/app/lib/tour/dashboardTourConfig.ts
@@ -86,7 +86,7 @@ export const DASHBOARD_TOUR_STEP_DEFS: DashboardTourStepDef[] = [
     selector: 'mobileTabBar',
     title: '◈ Quick navigation',
     description:
-      'Thumb reach shortcuts: Home, Positions, Watchlist, Import, Settings, and Utility — same routes as the header menu.',
+      'Thumb reach shortcuts: Home, Positions, Watchlist, Import, Settings, and Pricing — same routes as the header menu.',
     side: 'top',
     align: 'center',
     platforms: ['mobile'],

--- a/app/styles/brand.css
+++ b/app/styles/brand.css
@@ -1066,41 +1066,6 @@ body:has(header.brand-header) {
   }
 }
 
-/* Heartbeat animation for sponsor button */
-@keyframes heartbeat {
-  0% {
-    transform: scale(1);
-  }
-  10% {
-    transform: scale(1.15);
-  }
-  20% {
-    transform: scale(1);
-  }
-  30% {
-    transform: scale(1.15);
-  }
-  40% {
-    transform: scale(1);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-.sponsor-heart {
-  animation: heartbeat 1.5s ease-in-out infinite;
-  transform-origin: center;
-  display: inline-block;
-}
-
-/* Respect reduced motion preference */
-@media (prefers-reduced-motion: reduce) {
-  .sponsor-heart {
-    animation: none;
-  }
-}
-
 /* Mobile bottom TabBar — terminal / pro reference manual (token-driven, no SaaS orange slab) */
 .mobile-tab-bar.pp-tab-bar {
   display: flex !important;


### PR DESCRIPTION
## Summary
- Rename platform nav label from Utility to Pricing (marketing navbar, landing, TabBar, dashboard menus).
- Remove beating heart icon/animation; keep Stripe tier name Developer Utility unchanged.

## Test plan
- [ ] Landing/navbar shows Pricing (no heart)
- [ ] Mobile TabBar shows Pricing
- [ ] Dashboard menu shows Pricing linking to /sponsor