### PR TITLE
Enterprise bot allowlist: Google + Bing only

### DIFF
--- a/app/s/[symbol]/dividend-history/page.tsx
+++ b/app/s/[symbol]/dividend-history/page.tsx
@@ -246,6 +246,5 @@ export default async function DividendHistoryPage({ params }: { params: Promise<
   );
 }
 
-// Force dynamic rendering - client components fetch data at runtime
-export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+// ISR — client components still fetch live data; avoid per-hit origin bills for scrapers
+export const revalidate = 3600;

--- a/app/s/[symbol]/insider-trading/page.tsx
+++ b/app/s/[symbol]/insider-trading/page.tsx
@@ -539,6 +539,5 @@ export default async function InsiderTradingPage({ params }: { params: Promise<{
   );
 }
 
-// ISR configuration - 1 hour revalidation (insider data changes frequently)
-// Using 0 to force revalidation on every request until cache is stable
-export const revalidate = 0; // Force dynamic rendering for now
+// ISR — avoid per-request serverless bills when scrapers slip past the edge gate
+export const revalidate = 3600;

--- a/docs/command/cloudflare-waf-wave2-rules.md
+++ b/docs/command/cloudflare-waf-wave2-rules.md
@@ -42,38 +42,30 @@ Verify: Vercel → pocket-portfolio-app → Firewall → Custom Rules → “Wav
 and ip.geoip.asnum in {16509 14618 15169 396982 8075 14061 20473 24940 16276 13335 63949}
 and not http.user_agent contains "Googlebot"
 and not http.user_agent contains "bingbot"
-and not http.user_agent contains "OAI-SearchBot"
-and not http.user_agent contains "ChatGPT-User"
 ```
 
 **Action:** `Managed Challenge` (Turnstile / JS challenge)
 
-**Rationale:** Drops AWS (16509), GCP (15169/396982), Azure (8075), DigitalOcean (14061), Hetzner (24940), OVH (16276), Vultr (20473), Cloudflare (13335), Linode/Akamai (63949) scrapers before Vercel serverless invocation. Search crawlers and LLM citation bots are exempt.
+**Rationale:** Drops AWS (16509), GCP (15169/396982), Azure (8075), DigitalOcean (14061), Hetzner (24940), OVH (16276), Vultr (20473), Cloudflare (13335), Linode/Akamai (63949) scrapers before Vercel serverless invocation. **Enterprise allowlist: Googlebot + Bingbot only.**
 
 ---
 
-## Rule 2 — Symbol farm HTML rate posture (optional)
+## Rule 2 — Symbol farm HTML (Wave 2.1 — required)
 
-**Name:** `Wave2 — Challenge automation UA on symbol farm`
+**Name:** `Wave2.1 — Challenge datacenter ASN on symbol farm`
 
 **Expression:**
 
 ```text
 (http.request.uri.path eq "/s" or http.request.uri.path contains "/s/")
-and (
-  http.user_agent contains "python-requests"
-  or http.user_agent contains "curl/"
-  or http.user_agent contains "wget/"
-  or http.user_agent contains "scrapy"
-  or http.user_agent contains "HeadlessChrome"
-  or http.user_agent contains "Playwright"
-)
+and ip.geoip.asnum in {16509 14618 15169 396982 8075 14061 20473 24940 16276 63949}
 and not http.user_agent contains "Googlebot"
+and not http.user_agent contains "bingbot"
 ```
 
 **Action:** `Managed Challenge`
 
-**Note:** App middleware (PR #93) already redirects/challenges these at Next.js edge. This rule saves origin compute when Cloudflare sits in front of Vercel.
+**Companion deny:** known automation UAs (`python-requests`, `curl/`, `GPTBot`, `Bytespider`, …) on `/s/*` and metered APIs → **Block**. App middleware (`lib/bot-gate.ts`) also 307/401 any non-Google/Bing crawler and any Mozilla spoof missing `Sec-Fetch-*`.
 
 ---
 

--- a/docs/command/growth-report-command-org-2026-07-28.md
+++ b/docs/command/growth-report-command-org-2026-07-28.md
@@ -1,0 +1,204 @@
+# Command Team Growth Report — Wave 1–2 Ship Complete
+
+**Date:** 2026-07-28  
+**Status:** PRODUCTION LIVE · EDGE COST GATE GREEN · 14-DAY OBSERVATION OPEN  
+**Audience:** Command Team · Org Chart (CEO · CCO · CPO · Marketing · Product Eng · AI & Community · Creative Studios)  
+**Authority:** Board KPI Reset Memo · Wave 2 Engineering RFC · Analytics contamination remediation
+
+---
+
+## 1. Executive verdict (for CMD1 / CMD2)
+
+| Question | Answer |
+| --- | --- |
+| Did we stop steering on ghost Active Users? | **Yes.** Board Triad is the only north star. |
+| Is Wave 2 live? | **Yes.** PR #95 on production. |
+| Are we still paying Vercel for datacenter scrapers on metered APIs? | **No — ship gate GREEN.** Vercel Firewall ASN challenge live (PR #96 / rule Enabled). |
+| Can we spend ICP geo ads now? | **No.** Frozen until Day-14 review (**2026-08-10**). |
+| What closes the revenue measurement loop? | Marketing registers GA4 MP secret for `G-9FQ2NBHY7H`. |
+
+**One-line narrative for the Board:**  
+We replaced a contaminated 32k Active Users story with a defensible growth machine — human sessions, broker imports, paid API keys — and we no longer subsidize scrapers with serverless spend.
+
+---
+
+## 2. What shipped (production evidence)
+
+| PR | Date | Ship | Growth / cost effect |
+| --- | --- | --- | --- |
+| **#90** | Prior | Hybrid API hard gate | Scraper → 401 + Developer Utility upsell |
+| **#91** | 2026-07-27 | Wave 1 commercial SEO, triad docs, OP pillars, import dropzone | Brand/import SERP + KPI doctrine |
+| **#92** | 2026-07-27 | OP farm `noindex` hotfix | Crawl budget → institutional pillars |
+| **#93** | 2026-07-28 | Full bot gate (`/s/*` + tickers/quote/price/dividend) | Bot HTML redirect · API 401 |
+| **#94** | 2026-07-28 | Nav **Pricing** (was Utility), heart removed | Industry-standard monetization CTA |
+| **#95** | 2026-07-28 | Wave 2: llms feeds, robots, JSON-LD, Slack leads, geo banner | AI citation + enterprise pipeline + geo UX |
+| **#96** | 2026-07-28 | Firewall cost-gate confirmation | **Edge ASN challenge GREEN** |
+
+### Edge cost — why GREEN matters
+
+Production DNS is **Vercel-direct** (no `cf-ray`). Cloudflare Custom Rules cannot intercept that traffic. We published a **Vercel Firewall** rule instead:
+
+- **Name:** Wave2 Challenge datacenter ASN metered APIs  
+- **Match:** path `^/api/(tickers/|quote|price/|dividend)` **AND** datacenter ASN (AWS, GCP, Azure, DO, Hetzner, OVH, Vultr, Linode)  
+- **Action:** Challenge (before serverless invocation)  
+- **Verify:** `npx vercel@latest firewall rules list --expand` → Enabled  
+
+App-layer gates (PR #93) remain defense-in-depth for browser-spoofing bots and non-ASN paths.
+
+---
+
+## 3. Analytics alignment (the report that drove the pivot)
+
+### Problem (SOS / GA Realtime)
+
+| Contaminated signal | Reality |
+| --- | --- |
+| ~32k Active Users / 28d | Scrapers + `/s/*` farm + self-UTM loops |
+| ~2.3s avg engagement | Single-hit bots, not humans |
+| £0 attributed revenue | Free firehose; no measurable paid funnel in GA |
+| Realtime random tickers (`/s/aarhy`…) | Programmatic farm crawls |
+
+### Solution — Board Triad only
+
+| KPI | Definition | Owner of weekly number |
+| --- | --- | --- |
+| **Human Quality Sessions** | Engagement ≥30s **or** ≥1 key event; exclude self-UTM mediums | Head of Marketing |
+| **Broker Import Conversions** | `csv_import_success` | Marketing + Product Eng (event integrity) |
+| **Paid API Keys** | Active Developer Utility / Founders / Corporate (not Code Supporter) | CCO + Eng |
+
+**Retired as headline:** Active Users, raw `/s/*` Realtime counts, API hit volume.
+
+**Code contract:** `app/lib/analytics/clean-tracker.ts` → `BOARD_NORTH_STAR_KPIS`
+
+---
+
+## 4. Growth architecture (truthful funnel)
+
+```
+ACQUISITION                         ACTIVATION                      MONETIZATION
+─────────────                       ──────────                      ────────────
+Organic GSC (brand/import)    →   Human Quality Session (≥30s) →  csv_import_success
+ChatGPT / Perplexity / OAI    →   /learn/* pillars + llms.txt  →  contact → BIP / Tier 1
+Pricing CTA → /sponsor        →   Developer Utility checkout   →  Paid API key + MP event
+
+DEFENSIVE (not growth — exclude from triad)
+Scraper / datacenter ASN  →  Vercel Firewall Challenge / 401 / 307
+Self-UTM loops            →  clean-tracker → internal/self_nav
+```
+
+---
+
+## 5. Org chart — ownership matrix
+
+Aligned to `docs/command/roles/*`.
+
+| Role | Mandate touchpoint | Wave 1–2 ownership | Next 14 days |
+| --- | --- | --- | --- |
+| **CEO** | Mission, capital, board narrative | Enforces triad-only board packs; Day-14 go/no-go | Chair 2026-08-10 review; no vanity MAU in packs |
+| **CCO** | GTM, enterprise, API monetization | Paid API Keys KPI; BIP/enterprise Slack path | Pipeline on OP contact leads; freeze geo spend until Day-14 |
+| **CPO** | Product vision, UX trust | Pricing nav + geo compliance UX ratified | Watch import activation quality vs volume |
+| **Head of Product Engineering** | Infra, APIs, cost | Bot gate · Wave 2 ship · **Firewall GREEN** | Monitor Firewall Analytics; Slack env if missing |
+| **Head of Marketing** | Demand, positioning, attribution | Triad weekly sheet; GSC brand/import; Pricing copy | **GA4 MP secret**; GSC URL Inspection; weekly triad log |
+| **Head of AI & Community** | AI deployment, citation, brand face | Wave 2 llms/robots/JSON-LD for ChatGPT channel | Track AI referral sessions on `/learn/*`; citation narrative |
+| **Head of Creative Studios** | Brand SERP creative | Brand SERP tracking support | Assist GSC / creative for import CTR lift |
+
+---
+
+## 6. Open actions (not engineering blockers)
+
+| # | Action | Owner | Blocks |
+| --- | --- | --- | --- |
+| 1 | Register Measurement Protocol secret in GA4 Admin (`G-9FQ2NBHY7H`) matching Vercel `GA4_MEASUREMENT_PROTOCOL_SECRET` | Marketing + Eng | Visibility of `developer_utility_conversion` |
+| 2 | GSC URL Inspection: `/`, `/login`, top-10 `/import/*`, four `/learn/*` pillars | Marketing | SERP velocity |
+| 3 | Set `SLACK_ENTERPRISE_LEADS_WEBHOOK_URL` on Vercel (or confirm `FEEDBACK_P0_WEBHOOK_URL` fallback) | Eng / CCO | Real-time enterprise alerts |
+| 4 | Fill weekly triad in `board-triad-dashboard-wave1.md` | Marketing | Day-14 decision quality |
+| 5 | Optional later: Cloudflare orange-cloud DNS for dual-edge WAF | Eng / DevOps | Only after cost baseline on Vercel Firewall |
+
+**Still frozen until 2026-08-10:** paid ICP geo acquisition (UK/US/DE/CA/AU).
+
+---
+
+## 7. 14-day observation window
+
+| Milestone | Date | Success signal |
+| --- | --- | --- |
+| Observation start | 2026-07-28 | Wave 2 + Firewall live |
+| Week 1 triad | 2026-08-03 | Bot Realtime ↓ · Human Quality Sessions baseline |
+| Week 2 / Day-14 review | 2026-08-10 | Triad filled · import CTR vs 0.72% · AI referral on pillars · Wave 2 motion go/no-go |
+
+**Template:** `docs/command/wave1-day14-review-2026-08-10.md`
+
+---
+
+## 8. Role-specific one-pagers
+
+### CEO
+- Board packs: **Triad only**. Active Users appendix at most.  
+- Capital story: we cut scrapers’ free ride and edge-challenged datacenter API abuse.  
+- Decision date: **2026-08-10**.
+
+### CCO
+- Monetization path: scraper 401 → Pricing/sponsor → Stripe → paid key.  
+- Enterprise: Open contact → Firestore + Slack.  
+- Do **not** invent a £49 SKU; Developer Utility = Feature Voter prices.
+
+### CPO / Product Eng
+- Surfaces: Pricing nav, geo compliance banner, bot/API gates, Firewall GREEN.  
+- Re-verify: `node scripts/ops-publish-vercel-firewall-wave2.mjs` → GREEN.
+
+### Marketing
+- Own GA4 Explore triad + GSC sheets.  
+- Priority #1: MP secret in GA4 Admin.  
+- Language: **Pricing**, not Utility.
+
+### Head of AI & Community
+- ChatGPT was the converting AI channel (SOS: 141 sessions / 6 key events).  
+- Live assets: `/llms.txt`, `/llms-full.txt`, `/learn/*` allowlisted for OAI-SearchBot; `/api/` disallowed.  
+- Cite pillars, not ticker JSON.
+
+### Creative Studios
+- Support brand/import SERP creative and CTR tracking sheets.
+
+---
+
+## 9. Production smoke (Command can verify)
+
+| Surface | Check |
+| --- | --- |
+| Pocket | https://www.pocketportfolio.app/llms.txt |
+| Pocket | https://www.pocketportfolio.app/llms-full.txt |
+| Pocket | https://www.pocketportfolio.app/robots.txt (OAI-SearchBot + `/learn/`) |
+| Pocket | https://www.pocketportfolio.app/learn/sovereign-ai-architecture |
+| Open | https://www.openportfolio.co.uk/llms.txt |
+| Open | https://www.openportfolio.co.uk/ |
+| Cost gate | Vercel → Firewall → Wave2 Challenge rule **Enabled** |
+
+---
+
+## 10. Document index
+
+| Doc | Use |
+| --- | --- |
+| This report | Command / org weekly truth |
+| `board-kpi-reset-memo-2026-07-27.md` | Triad law |
+| `board-triad-dashboard-wave1.md` | Weekly numbers |
+| `wave1-day14-review-2026-08-10.md` | Day-14 decision |
+| `wave2-engineering-rfc-2026-07-28.md` | Engineering doctrine |
+| `cloudflare-waf-wave2-rules.md` | Edge WAF (Vercel-first) |
+| `growth-report-pre-prod-2026-07-28.md` | Pre-merge engineering brief (superseded by this for status) |
+| `docs/command/roles/*.md` | Org mandates |
+
+---
+
+## 11. Command verdict
+
+| Gate | Status |
+| --- | --- |
+| Wave 1 defense (hygiene + bot/API monetization) | ✅ LIVE |
+| Wave 2 offense (citation · enterprise Slack · geo) | ✅ LIVE |
+| Edge cost gate (no paying for datacenter API bots) | ✅ **GREEN** |
+| Enterprise crawler allowlist (Google + Bing only) | ✅ App gate + Firewall Wave 2.1 |
+| Measurement loop (GA4 MP Admin) | ⏳ Marketing |
+| Paid geo spend | 🔒 Until 2026-08-10 |
+
+**Recommendation:** Accept this report as the Command Team growth baseline. Execute open Marketing actions. Reconvene **2026-08-10** with filled triad — then decide geo spend and Wave 2.1 (BYOC sandbox, CRM enrichment).

--- a/lib/bot-gate-middleware.ts
+++ b/lib/bot-gate-middleware.ts
@@ -36,7 +36,8 @@ async function withinSurfacePageBudget(ip: string): Promise<boolean> {
 
 /**
  * Edge paywall for symbol-farm HTML and automated clients on metered surfaces.
- * Search crawlers may index HTML; humans get a generous page budget before upsell.
+ * Enterprise: ONLY Googlebot + Bingbot may crawl; all other bots → 307/401.
+ * Humans (real Sec-Fetch browser signals) get a page budget before upsell.
  */
 export async function applyBotGateMiddleware(
   request: NextRequest,

--- a/lib/bot-gate.ts
+++ b/lib/bot-gate.ts
@@ -25,16 +25,18 @@ const TRUSTED_APP_PATH_PREFIXES = [
   '/static',
 ] as const;
 
+/**
+ * Enterprise allowlist — ONLY Google + Bing may crawl gated surfaces.
+ * All other bots/crawlers (SEO farms, LLM scrapers, social previews, etc.) are blocked.
+ * Humans with real browser signals remain allowed.
+ */
 const SEARCH_CRAWLER_HINTS = [
   'googlebot',
+  'google-inspectiontool',
+  'adsbot-google',
   'bingbot',
-  'duckduckbot',
-  'yandexbot',
-  'applebot',
-  'facebookexternalhit',
-  'linkedinbot',
-  'twitterbot',
-  'slackbot',
+  'bingpreview',
+  'msnbot',
 ] as const;
 
 const AUTOMATION_UA_HINTS = [
@@ -68,10 +70,28 @@ const AUTOMATION_UA_HINTS = [
   'petalbot',
   'bytespider',
   'gptbot',
+  'chatgpt-user',
+  'oai-searchbot',
   'claudebot',
+  'claude-web',
   'anthropic-ai',
   'ccbot',
+  'perplexitybot',
+  'duckduckbot',
+  'yandexbot',
+  'applebot',
+  'facebookexternalhit',
+  'linkedinbot',
+  'twitterbot',
+  'slackbot',
+  'discordbot',
+  'whatsapp',
+  'telegrambot',
 ] as const;
+
+/** Generic crawler tokens — blocked unless on the Google/Bing allowlist. */
+const GENERIC_BOT_UA_RE =
+  /\b(bot|crawler|spider|slurp|scrapy|fetcher|monitor|checker|archive)\b/i;
 
 export function isSymbolFarmPath(pathname: string): boolean {
   return pathname === '/s' || pathname.startsWith('/s/');
@@ -189,21 +209,28 @@ export function isLikelyAutomatedClient(request: NextRequest): boolean {
   const ua = (request.headers.get('user-agent') || '').toLowerCase();
   if (!ua || ua === 'unknown') return true;
 
+  // Google + Bing only — every other crawler is treated as automation.
   if (isAllowedSearchCrawler(request)) return false;
 
   if (AUTOMATION_UA_HINTS.some((hint) => ua.includes(hint))) return true;
+  if (GENERIC_BOT_UA_RE.test(ua)) return true;
 
   const secFetchMode = (request.headers.get('sec-fetch-mode') || '').toLowerCase();
   const secFetchSite = (request.headers.get('sec-fetch-site') || '').toLowerCase();
-  if (!secFetchMode && !secFetchSite && !request.headers.get('origin')) {
-    const accept = (request.headers.get('accept') || '').toLowerCase();
-    if (
-      accept.includes('application/json') &&
-      !accept.includes('text/html') &&
-      !ua.includes('mozilla/')
-    ) {
-      return true;
-    }
+  const hasSecFetch = Boolean(secFetchMode || secFetchSite);
+
+  // Spoofed "Chrome" scrapers almost always omit Sec-Fetch-*. Real browsers send them.
+  if (!hasSecFetch) return true;
+
+  const accept = (request.headers.get('accept') || '').toLowerCase();
+  if (
+    accept.includes('application/json') &&
+    !accept.includes('text/html') &&
+    !request.headers.get('origin') &&
+    secFetchMode !== 'cors' &&
+    secFetchMode !== 'same-origin'
+  ) {
+    return true;
   }
 
   return false;

--- a/scripts/ops-publish-vercel-firewall-wave2.mjs
+++ b/scripts/ops-publish-vercel-firewall-wave2.mjs
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 /**
- * Wave 2 ship gate — publish Vercel Firewall ASN challenge BEFORE serverless billing.
+ * Wave 2.1 ship gate — Vercel Firewall BEFORE serverless billing.
+ *
+ * Rules:
+ *   1) Challenge datacenter ASNs on metered APIs
+ *   2) Challenge datacenter ASNs on /s/* (exempt Googlebot + Bingbot)
+ *   3) Deny known automation UAs on /s/* and metered APIs (exempt Google/Bing)
  *
  * Uses VERCEL_TOKEN env, or falls back to Vercel CLI auth at:
  *   %APPDATA%/com.vercel.cli/Data/auth.json
@@ -14,42 +19,85 @@ import { join } from 'node:path';
 const PROJECT_ID = 'prj_xmupQQfumETKPAmKooDEPMjeAfz2';
 const TEAM_ID = 'team_xEo3S3FB1aFM2xV5gxZY36Gj';
 
-const RULE = {
-  name: 'Wave2 Challenge datacenter ASN metered APIs',
-  active: true,
-  conditionGroup: [
-    {
-      conditions: [
-        {
-          type: 'path',
-          op: 're',
-          value: '^/api/(tickers/|quote|price/|dividend)',
-        },
-        {
-          type: 'geo_as_number',
-          op: 'inc',
-          value: [
-            '16509',
-            '14618',
-            '15169',
-            '396982',
-            '8075',
-            '14061',
-            '20473',
-            '24940',
-            '16276',
-            '63949',
-          ],
-        },
-      ],
-    },
-  ],
-  action: {
-    mitigate: {
-      action: 'challenge',
-    },
+const DATACENTER_ASNS = [
+  '16509', // AWS
+  '14618', // Amazon
+  '15169', // Google
+  '396982', // Google Cloud
+  '8075', // Microsoft
+  '14061', // DigitalOcean
+  '20473', // Vultr
+  '24940', // Hetzner
+  '16276', // OVH
+  '63949', // Linode
+];
+
+const METERED_API_PATH = '^/api/(tickers/|quote|price/|dividend)';
+const SYMBOL_FARM_PATH = '^/s(/|$)';
+
+/** Enterprise: Google + Bing only — negate these so verified crawlers are not challenged/denied. */
+const GOOGLE_BING_EXEMPT = [
+  { type: 'user_agent', op: 'sub', value: 'Googlebot', neg: true },
+  { type: 'user_agent', op: 'sub', value: 'Google-InspectionTool', neg: true },
+  { type: 'user_agent', op: 'sub', value: 'AdsBot-Google', neg: true },
+  { type: 'user_agent', op: 'sub', value: 'bingbot', neg: true },
+  { type: 'user_agent', op: 'sub', value: 'BingPreview', neg: true },
+  { type: 'user_agent', op: 'sub', value: 'msnbot', neg: true },
+];
+
+const RULES = [
+  {
+    name: 'Wave2 Challenge datacenter ASN metered APIs',
+    active: true,
+    conditionGroup: [
+      {
+        conditions: [
+          { type: 'path', op: 're', value: METERED_API_PATH },
+          { type: 'geo_as_number', op: 'inc', value: DATACENTER_ASNS },
+          ...GOOGLE_BING_EXEMPT,
+        ],
+      },
+    ],
+    action: { mitigate: { action: 'challenge' } },
   },
-};
+  {
+    name: 'Wave2.1 Challenge datacenter ASN symbol farm',
+    active: true,
+    conditionGroup: [
+      {
+        conditions: [
+          { type: 'path', op: 're', value: SYMBOL_FARM_PATH },
+          { type: 'geo_as_number', op: 'inc', value: DATACENTER_ASNS },
+          ...GOOGLE_BING_EXEMPT,
+        ],
+      },
+    ],
+    action: { mitigate: { action: 'challenge' } },
+  },
+  {
+    name: 'Wave2.1 Deny automation UA on farm and APIs',
+    active: true,
+    conditionGroup: [
+      {
+        conditions: [
+          {
+            type: 'path',
+            op: 're',
+            value: '^/(s(/|$)|api/(tickers/|quote|price/|dividend))',
+          },
+          {
+            type: 'user_agent',
+            op: 're',
+            value:
+              '(python-requests|curl/|wget/|scrapy|HeadlessChrome|Playwright|puppeteer|GPTBot|ClaudeBot|Bytespider|SemrushBot|AhrefsBot|PetalBot|CCBot|PerplexityBot|DuckDuckBot|YandexBot|Applebot|facebookexternalhit)',
+          },
+          ...GOOGLE_BING_EXEMPT,
+        ],
+      },
+    ],
+    action: { mitigate: { action: 'deny' } },
+  },
+];
 
 function resolveToken() {
   if (process.env.VERCEL_TOKEN?.trim()) return process.env.VERCEL_TOKEN.trim();
@@ -82,20 +130,50 @@ async function api(token, body) {
   return { ok: res.ok, status: res.status, json };
 }
 
-function ruleIsActive(cfg) {
-  const rules = cfg?.active?.rules || [];
-  return rules.some(
-    (r) =>
-      r.active &&
-      String(r.name || '').includes('Wave2 Challenge datacenter ASN') &&
-      r.action?.mitigate?.action === 'challenge',
-  );
+function activeRuleNames(cfg) {
+  return (cfg?.active?.rules || [])
+    .filter((r) => r.active)
+    .map((r) => String(r.name || ''));
+}
+
+function rulePresent(names, needle) {
+  return names.some((n) => n.includes(needle));
+}
+
+async function ensureRule(token, rule) {
+  const before = await api(token);
+  if (!before.ok) {
+    console.error('RED: Cannot read firewall config', before.status, before.json);
+    process.exit(1);
+  }
+  const names = activeRuleNames(before.json);
+  if (rulePresent(names, rule.name)) {
+    console.log(`GREEN: already active — ${rule.name}`);
+    return;
+  }
+  console.log(`Inserting — ${rule.name}`);
+  const insert = await api(token, {
+    action: 'rules.insert',
+    id: null,
+    value: rule,
+  });
+  if (!insert.ok) {
+    console.error('RED: rules.insert failed', insert.status, insert.json);
+    process.exit(1);
+  }
+  const after = await api(token);
+  const afterNames = activeRuleNames(after.json);
+  if (!rulePresent(afterNames, rule.name)) {
+    console.error('RED: inserted but not active', rule.name, after.json);
+    process.exit(1);
+  }
+  console.log(`GREEN: LIVE — ${rule.name}`);
 }
 
 async function main() {
   writeFileSync(
     join(process.cwd(), 'scripts', 'wave2-vercel-firewall-rule.json'),
-    JSON.stringify(RULE, null, 2) + '\n',
+    JSON.stringify(RULES, null, 2) + '\n',
   );
 
   const token = resolveToken();
@@ -104,40 +182,15 @@ async function main() {
     process.exit(1);
   }
 
-  const before = await api(token);
-  if (!before.ok) {
-    console.error('RED: Cannot read firewall config', before.status, before.json);
-    process.exit(1);
+  for (const rule of RULES) {
+    await ensureRule(token, rule);
   }
 
-  if (ruleIsActive(before.json)) {
-    console.log('GREEN: Wave2 ASN challenge already active on production firewall');
-    process.exit(0);
-  }
-
-  console.log('Inserting Wave2 ASN challenge rule…');
-  const insert = await api(token, {
-    action: 'rules.insert',
-    id: null,
-    value: RULE,
-  });
-  if (!insert.ok) {
-    console.error('RED: rules.insert failed', insert.status, insert.json);
-    process.exit(1);
-  }
-
-  // Some API versions insert directly into active; verify.
-  const after = await api(token);
-  if (ruleIsActive(after.json)) {
-    console.log('GREEN: Wave2 ASN challenge is LIVE (active.rules)');
-    console.log('  Paths: ^/api/(tickers/|quote|price/|dividend)');
-    console.log('  ASNs: AWS/GCP/Azure/DO/Hetzner/OVH/Vultr/Linode');
-    console.log('  Action: challenge (before serverless invocation)');
-    process.exit(0);
-  }
-
-  console.error('RED: Rule inserted but not found in active config', after.status, after.json);
-  process.exit(1);
+  console.log('');
+  console.log('GREEN: Wave 2.1 enterprise bot posture published');
+  console.log('  Allow crawlers: Googlebot + Bingbot only');
+  console.log('  /s/* + metered APIs: datacenter ASN → challenge');
+  console.log('  Known automation UAs → deny');
 }
 
 main().catch((e) => {

--- a/scripts/wave2-vercel-firewall-rule.json
+++ b/scripts/wave2-vercel-firewall-rule.json
@@ -1,36 +1,207 @@
-{
-  "name": "Wave2 Challenge datacenter ASN metered APIs",
-  "active": true,
-  "conditionGroup": [
-    {
-      "conditions": [
-        {
-          "type": "path",
-          "op": "re",
-          "value": "^/api/(tickers/|quote|price/|dividend)"
-        },
-        {
-          "type": "geo_as_number",
-          "op": "inc",
-          "value": [
-            "16509",
-            "14618",
-            "15169",
-            "396982",
-            "8075",
-            "14061",
-            "20473",
-            "24940",
-            "16276",
-            "63949"
-          ]
-        }
-      ]
+[
+  {
+    "name": "Wave2 Challenge datacenter ASN metered APIs",
+    "active": true,
+    "conditionGroup": [
+      {
+        "conditions": [
+          {
+            "type": "path",
+            "op": "re",
+            "value": "^/api/(tickers/|quote|price/|dividend)"
+          },
+          {
+            "type": "geo_as_number",
+            "op": "inc",
+            "value": [
+              "16509",
+              "14618",
+              "15169",
+              "396982",
+              "8075",
+              "14061",
+              "20473",
+              "24940",
+              "16276",
+              "63949"
+            ]
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "Googlebot",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "Google-InspectionTool",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "AdsBot-Google",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "bingbot",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "BingPreview",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "msnbot",
+            "neg": true
+          }
+        ]
+      }
+    ],
+    "action": {
+      "mitigate": {
+        "action": "challenge"
+      }
     }
-  ],
-  "action": {
-    "mitigate": {
-      "action": "challenge"
+  },
+  {
+    "name": "Wave2.1 Challenge datacenter ASN symbol farm",
+    "active": true,
+    "conditionGroup": [
+      {
+        "conditions": [
+          {
+            "type": "path",
+            "op": "re",
+            "value": "^/s(/|$)"
+          },
+          {
+            "type": "geo_as_number",
+            "op": "inc",
+            "value": [
+              "16509",
+              "14618",
+              "15169",
+              "396982",
+              "8075",
+              "14061",
+              "20473",
+              "24940",
+              "16276",
+              "63949"
+            ]
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "Googlebot",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "Google-InspectionTool",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "AdsBot-Google",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "bingbot",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "BingPreview",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "msnbot",
+            "neg": true
+          }
+        ]
+      }
+    ],
+    "action": {
+      "mitigate": {
+        "action": "challenge"
+      }
+    }
+  },
+  {
+    "name": "Wave2.1 Deny automation UA on farm and APIs",
+    "active": true,
+    "conditionGroup": [
+      {
+        "conditions": [
+          {
+            "type": "path",
+            "op": "re",
+            "value": "^/(s(/|$)|api/(tickers/|quote|price/|dividend))"
+          },
+          {
+            "type": "user_agent",
+            "op": "re",
+            "value": "(python-requests|curl/|wget/|scrapy|HeadlessChrome|Playwright|puppeteer|GPTBot|ClaudeBot|Bytespider|SemrushBot|AhrefsBot|PetalBot|CCBot|PerplexityBot|DuckDuckBot|YandexBot|Applebot|facebookexternalhit)"
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "Googlebot",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "Google-InspectionTool",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "AdsBot-Google",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "bingbot",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "BingPreview",
+            "neg": true
+          },
+          {
+            "type": "user_agent",
+            "op": "sub",
+            "value": "msnbot",
+            "neg": true
+          }
+        ]
+      }
+    ],
+    "action": {
+      "mitigate": {
+        "action": "deny"
+      }
     }
   }
-}
+]

--- a/tests/unit/bot-gate.spec.ts
+++ b/tests/unit/bot-gate.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { NextRequest } from 'next/server';
 import {
+  isAllowedSearchCrawler,
   isFirstPartyTickerRequest,
   isLikelyAutomatedClient,
   isSymbolFarmPath,
@@ -51,9 +52,68 @@ describe('bot-gate', () => {
     expect(isLikelyAutomatedClient(request)).toBe(true);
   });
 
-  it('allows verified search crawlers for HTML indexing', () => {
+  it('allows Googlebot for HTML indexing', () => {
     const request = req('https://www.pocketportfolio.app/s/spy', {
-      headers: { 'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' },
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      },
+    });
+    expect(isAllowedSearchCrawler(request)).toBe(true);
+    expect(isLikelyAutomatedClient(request)).toBe(false);
+  });
+
+  it('allows Bingbot for HTML indexing', () => {
+    const request = req('https://www.pocketportfolio.app/s/spy', {
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+      },
+    });
+    expect(isAllowedSearchCrawler(request)).toBe(true);
+    expect(isLikelyAutomatedClient(request)).toBe(false);
+  });
+
+  it('blocks non-Google/Bing crawlers (enterprise allowlist)', () => {
+    for (const ua of [
+      'Mozilla/5.0 (compatible; DuckDuckBot/1.0)',
+      'Mozilla/5.0 (compatible; YandexBot/3.0)',
+      'Mozilla/5.0 Applebot/0.1',
+      'facebookexternalhit/1.1',
+      'GPTBot/1.0',
+      'ClaudeBot/1.0',
+      'PerplexityBot/1.0',
+      'Bytespider',
+    ]) {
+      const request = req('https://www.pocketportfolio.app/s/spy', {
+        headers: { 'user-agent': ua },
+      });
+      expect(isAllowedSearchCrawler(request)).toBe(false);
+      expect(isLikelyAutomatedClient(request)).toBe(true);
+    }
+  });
+
+  it('blocks spoofed Chrome UA without Sec-Fetch (Realtime farm gap)', () => {
+    const request = req('https://www.pocketportfolio.app/s/apacu/json-api', {
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0',
+        accept: 'text/html',
+      },
+    });
+    expect(isLikelyAutomatedClient(request)).toBe(true);
+  });
+
+  it('allows real browser navigations with Sec-Fetch', () => {
+    const request = req('https://www.pocketportfolio.app/s/spy', {
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        accept: 'text/html,application/xhtml+xml',
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-site': 'none',
+        'sec-fetch-dest': 'document',
+      },
     });
     expect(isLikelyAutomatedClient(request)).toBe(false);
   });


### PR DESCRIPTION
﻿## Summary
- Restrict crawler allowlist to **Googlebot + Bingbot** (plus Google Inspection / AdsBot / BingPreview / msnbot). All other bots on `/s/*` and metered APIs get 307/401.
- Close spoofed-Chrome gap: missing Sec-Fetch headers treated as automation (Realtime farm crawlers).
- Publish Wave 2.1 Vercel Firewall: challenge datacenter ASN on `/s/*`, deny known automation UAs (already LIVE on edge).
- Switch insider-trading / dividend-history farm pages off revalidate=0 to cut residual origin cost.

## Test plan
- [x] vitest bot-gate.spec.ts (9 pass)
- [x] Firewall publish script GREEN for Wave2.1 rules
- [ ] After merge: curl spoofed Chrome UA without Sec-Fetch to /s/apacu/json-api returns 307
- [ ] Real Chrome browser navigation to /s/spy returns 200
- [ ] Googlebot UA returns 200; python-requests returns 307/deny
- [ ] GA4 Realtime /s/* noise drops after deploy
