### PR TITLE
Open Portfolio: remove Command jargon from buyer surfaces

### DIFF
--- a/app/components/learn/SovereignPillarArticle.tsx
+++ b/app/components/learn/SovereignPillarArticle.tsx
@@ -1,6 +1,6 @@
 /**
- * Shared institutional pillar page shell for Open Portfolio Wave 1 doctrine.
- * Wave 2: TechArticle JSON-LD for LLM citation.
+ * Shared institutional pillar page shell for Open Portfolio architecture briefs.
+ * TechArticle JSON-LD for search and citation agents.
  */
 import Link from 'next/link';
 import { OPEN_URLS, SURFACE_ORG } from '@/lib/canonical-claims';

--- a/app/learn/enterprise-design-partnership/page.tsx
+++ b/app/learn/enterprise-design-partnership/page.tsx
@@ -2,16 +2,16 @@ import type { Metadata } from 'next';
 import SovereignPillarArticle from '@/app/components/learn/SovereignPillarArticle';
 
 export const metadata: Metadata = {
-  title: 'Enterprise Design Partnership Program (5-Seat BIP Cap)',
+  title: 'Enterprise Design Partnership Program',
   description:
-    'Open Portfolio Enterprise Design Partnership and Board of Investors (BIP) — capped seats for platforms building sovereign ingestion and inference into wealth-tech stacks.',
+    'Architecture-level design partnership for wealth-tech platforms building sovereign ingestion, inference boundaries, and audit-perimeter controls.',
   alternates: {
     canonical: 'https://www.openportfolio.co.uk/learn/enterprise-design-partnership',
   },
   openGraph: {
-    title: 'Enterprise Design Partnership (5-Seat BIP Cap) | Open Portfolio',
+    title: 'Enterprise Design Partnership Program | Open Portfolio',
     description:
-      'Capped institutional partnership for sovereign AI architecture in wealth-tech.',
+      'Limited-capacity design partnership for sovereign AI architecture in regulated wealth-tech.',
     url: 'https://www.openportfolio.co.uk/learn/enterprise-design-partnership',
     type: 'article',
   },
@@ -22,15 +22,15 @@ export default function EnterpriseDesignPartnershipPage() {
     <SovereignPillarArticle
       articleSlug="enterprise-design-partnership"
       breadcrumbLabel="Enterprise Design Partnership"
-      title="Enterprise Design Partnership Program (5-Seat BIP Cap)"
-      subtitle="Institutional access is scarce by design — not another open blog farm."
+      title="Enterprise Design Partnership Program"
+      subtitle="Architecture-level collaboration for platforms that cannot warehouse client ledgers."
       body={[
-        'The Enterprise Design Partnership and Board of Investors (BIP) tracks exist for platforms and operators who need architecture-level collaboration on sovereign ingestion, inference boundaries, and commercial packaging — not generic “how to speed up CI” content.',
-        'Seat scarcity (including the five-seat BIP posture) protects signal quality: diligence conversations stay with buyers who care about data perimeters, DORA/AI Act posture, and API monetization that does not leak the ledger.',
-        'Wave 1 of the commercial offense retires thin engineering SEO farm posts in favor of these pillars. Wave 2 (CCO outbound and AI citation) starts only after this doctrine is indexable and measurable.',
+        'The Enterprise Design Partnership is for wealth-tech platforms and operators who need direct engineering collaboration on data perimeters, inference boundaries, and commercial packaging — not surface-level content.',
+        'Partnership capacity is intentionally limited so diligence conversations stay with buyers who care about DORA and EU AI Act posture, audit perimeter reduction, and API access models that do not duplicate client ledgers in your cloud.',
+        'Evaluate the published architecture briefs first, then start a Tier 1 design conversation with your audit-perimeter requirements. We structure engagement around CTO and CISO diligence — not marketing funnels.',
       ]}
-      ctaHref="/board-of-investors"
-      ctaLabel="Board of Investors (BIP)"
+      ctaHref="/tier1designpartner"
+      ctaLabel="Explore Design Partnership"
     />
   );
 }

--- a/app/learn/sovereign-ai-architecture/page.tsx
+++ b/app/learn/sovereign-ai-architecture/page.tsx
@@ -23,9 +23,9 @@ export default function SovereignAiArchitecturePage() {
       title="Sovereign AI Architecture & Data Perimeters"
       subtitle="Inference without a central warehouse. Ingestion without surrendering the ledger."
       body={[
-        'Wealth-tech platforms are punished twice for “AI-ready” data lakes: once on infrastructure cost, and again on regulatory perimeter. Open Portfolio’s doctrine is the opposite — keep the raw broker ledger at the edge (browser, operator device, or customer-controlled Drive), and send only sanitized context into a stateless inference boundary.',
-        'Data perimeters are architectural, not policy theatre. Client-side CSV/Excel parsing, IndexedDB-local state, and optional operator-owned sync mean PII does not need to become a permanent cloud liability to unlock portfolio intelligence.',
-        'For CTOs and CISOs: treat AI as a bounded processor. The sovereign stack separates ingestion (local), control plane (auth/quotas), and inference (stateless) so enterprise buyers can reason over broker data without subsidizing a scrapable firehose or a GDPR-grade warehouse.',
+        'Wealth-tech platforms are punished twice for “AI-ready” data lakes: once on infrastructure cost, and again on regulatory perimeter. Open Portfolio keeps the raw broker ledger at the edge (browser, operator device, or customer-controlled Drive), and sends only sanitized context into a stateless inference boundary.',
+        'Data perimeters are architectural, not checkbox compliance alone. Client-side CSV/Excel parsing, IndexedDB-local state, and optional operator-owned sync mean PII does not need to become a permanent cloud liability to unlock portfolio intelligence.',
+        'For CTOs and CISOs: treat AI as a bounded processor. The sovereign stack separates ingestion (local), control plane (auth/quotas), and inference (stateless) so enterprise buyers can reason over broker data without exposing unmetered public data endpoints or building a GDPR-grade warehouse.',
       ]}
       ctaHref="/architecture"
       ctaLabel="Read the architecture"

--- a/app/learn/stateless-edge-ingestion/page.tsx
+++ b/app/learn/stateless-edge-ingestion/page.tsx
@@ -23,9 +23,9 @@ export default function StatelessEdgeIngestionPage() {
       title="Stateless Edge Ingestion vs Centralized Data Warehousing"
       subtitle="Stop paying warehouse rent for data you should never hold."
       body={[
-        'Centralized warehousing promises “one source of truth.” In practice it creates a second source of liability: storage cost, scraper attack surface, and regulatory exposure that compounds with every broker integration.',
+        'Centralized warehousing promises “one source of truth.” In practice it creates a second source of liability: storage cost, elevated attack surface, and regulatory exposure that compounds with every broker integration.',
         'Edge ingestion flips the model. Broker exports parse where the operator already has the file. Normalized trades stay local-first. Inference receives a sanitized snapshot for the duration of the request — no permanent per-user ledger mirror required for core product value.',
-        'The commercial implication after PR #90: hosted raw ticker firehoses are a paid API product, not a free commons. Crawl budget and engineering time belong on institutional narratives and high-intent import conversion — not on feeding anonymous extractors.',
+        'Hosted market-data APIs are metered products for automated access — not an open data commons. Engineering investment concentrates on institutional architecture and operator import workflows, not on subsidizing anonymous bulk extraction.',
       ]}
       ctaHref="/learn/sovereign-finance"
       ctaLabel="Economics of Stateless Inference"

--- a/app/open/_components/OpenContactForm.tsx
+++ b/app/open/_components/OpenContactForm.tsx
@@ -16,7 +16,7 @@ import { OPEN_LANDING_COPY } from '../../../lib/canonical-claims';
 const CONTEXT_OPTIONS = [
   { value: 'tier1', label: 'Tier 1 / clean-room partnership' },
   { value: 'design-challenge', label: 'Design Challenge submission' },
-  { value: 'investor', label: 'Investor / BIP' },
+  { value: 'investor', label: 'Board of Investors (seed round)' },
   { value: 'grant', label: 'Sovereign AI Grant' },
   { value: 'general', label: 'General inquiry' },
 ] as const;
@@ -278,11 +278,8 @@ export default function OpenContactForm() {
                   maxWidth: '380px',
                 }}
               >
-                Submissions persist to a private Firestore collection and surface in
-                <code style={{ fontFamily: 'ui-monospace', fontSize: '12px', margin: '0 4px' }}>
-                  /admin/analytics
-                </code>
-                only. No third-party form provider.
+                Submissions are stored privately on our infrastructure. No third-party form
+                provider or marketing pixel.
               </p>
               <motion.button
                 type="submit"

--- a/app/open/learn/enterprise-design-partnership/page.tsx
+++ b/app/open/learn/enterprise-design-partnership/page.tsx
@@ -4,13 +4,14 @@ import { OPEN_URLS, SURFACE_ORG } from '../../../../lib/canonical-claims';
 export { default } from '../../../learn/enterprise-design-partnership/page';
 
 export const metadata: Metadata = {
-  title: 'Enterprise Design Partnership Program (5-Seat BIP Cap)',
+  title: 'Enterprise Design Partnership Program',
   description:
-    'Capped institutional Design Partnership and Board of Investors access for sovereign AI architecture.',
+    'Architecture-level design partnership for sovereign ingestion and inference in regulated wealth-tech.',
   alternates: { canonical: OPEN_URLS.enterpriseDesignPartnership },
   openGraph: {
-    title: 'Enterprise Design Partnership | Open Portfolio',
-    description: '5-seat BIP cap — institutional partnership for sovereign wealth-tech stacks.',
+    title: 'Enterprise Design Partnership Program | Open Portfolio',
+    description:
+      'Limited-capacity design partnership for sovereign AI architecture in wealth-tech stacks.',
     url: OPEN_URLS.enterpriseDesignPartnership,
     siteName: SURFACE_ORG.open.name,
     type: 'article',

--- a/lib/llms-feed.ts
+++ b/lib/llms-feed.ts
@@ -1,5 +1,5 @@
 /**
- * SSOT builders for /llms.txt and /llms-full.txt (Wave 2 Pillar 1).
+ * SSOT builders for /llms.txt and /llms-full.txt.
  * Consumed by edge routes and scripts/build-llms-txt.ts prebuild.
  */
 import {
@@ -24,7 +24,7 @@ import {
 
 const generatedAt = `${LAST_HUMAN_VERIFIED}T00:00:00Z`;
 
-const WAVE1_PILLARS = [
+const INSTITUTIONAL_PILLARS = [
   {
     title: 'Sovereign AI Architecture & Data Perimeters',
     url: OPEN_URLS.sovereignAiArchitecture,
@@ -47,8 +47,8 @@ function packagesSection(): string {
   return PACKAGES.map((pkg) => `- ${pkg.name} — ${pkg.description}`).join('\n');
 }
 
-function wave1PillarsSection(): string {
-  return WAVE1_PILLARS.map((p) => `- [${p.title}](${p.url})`).join('\n');
+function institutionalPillarsSection(): string {
+  return INSTITUTIONAL_PILLARS.map((p) => `- [${p.title}](${p.url})`).join('\n');
 }
 
 /** Pocket Portfolio summary feed (consumer + developer context). */
@@ -76,8 +76,8 @@ Secondary phrasing: ${POSITIONING.secondary}
 ## What We Are
 ${TAGLINE_LONG}
 
-## Wave 1 Institutional Pillars (Open Portfolio doctrine)
-${wave1PillarsSection()}
+## Institutional Architecture Briefs (Open Portfolio)
+${institutionalPillarsSection()}
 
 ## SDK
 - Primary package: ${SDK.name} v${SDK.version} (${SDK.license})
@@ -131,8 +131,8 @@ Secondary phrasing: ${SURFACE_POSITIONING.open.secondary}
 ## What We Are
 Open Portfolio is the B2B developer and infrastructure gateway for the sovereign ingestion substrate that powers Pocket Portfolio. Local-first import SDK plus stateless AI reasoning — platforms reason over broker data without warehousing PII.
 
-## Primary System Architecture (Wave 1 pillars)
-${wave1PillarsSection()}
+## Institutional Architecture Briefs
+${institutionalPillarsSection()}
 
 ## Data Perimeter & Security
 Open Portfolio enforces a Split-Brain execution model. Frontier models operate as invited guests — never receiving raw data warehouses or PII.
@@ -175,8 +175,8 @@ Open Portfolio provides sovereign financial data infrastructure. Raw enterprise 
 
 Pocket Portfolio is the live consumer reference terminal — every edge-case CSV upload hardens the enterprise adapter floor.
 
-## 2. Wave 1 Institutional Pillars
-${wave1PillarsSection()}
+## 2. Institutional Architecture Briefs
+${institutionalPillarsSection()}
 
 ## 3. Security Boundaries & Compliance
 - **DORA:** Eliminates single points of failure by storing data client-side (browser IndexedDB, operator-controlled Drive).

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,7 +10,7 @@ Secondary phrasing: The sovereign financial data layer.
 ## What We Are
 Pocket Portfolio is the Sovereign Ingestion & Inference Layer for wealth-tech: a local-first import SDK plus stateless AI reasoning that lets platforms and operators reason over broker data without warehousing PII.
 
-## Wave 1 Institutional Pillars (Open Portfolio doctrine)
+## Institutional Architecture Briefs (Open Portfolio)
 - [Sovereign AI Architecture & Data Perimeters](https://www.openportfolio.co.uk/learn/sovereign-ai-architecture)
 - [DORA & EU AI Act for Wealth Management](https://www.openportfolio.co.uk/learn/dora-eu-ai-act-wealth)
 - [Stateless Edge Ingestion](https://www.openportfolio.co.uk/learn/stateless-edge-ingestion)

--- a/public/open/llms.txt
+++ b/public/open/llms.txt
@@ -10,7 +10,7 @@ Secondary phrasing: The sovereign financial data layer.
 ## What We Are
 Open Portfolio is the B2B developer and infrastructure gateway for the sovereign ingestion substrate that powers Pocket Portfolio. Local-first import SDK plus stateless AI reasoning — platforms reason over broker data without warehousing PII.
 
-## Primary System Architecture (Wave 1 pillars)
+## Institutional Architecture Briefs
 - [Sovereign AI Architecture & Data Perimeters](https://www.openportfolio.co.uk/learn/sovereign-ai-architecture)
 - [DORA & EU AI Act for Wealth Management](https://www.openportfolio.co.uk/learn/dora-eu-ai-act-wealth)
 - [Stateless Edge Ingestion](https://www.openportfolio.co.uk/learn/stateless-edge-ingestion)

--- a/tests/unit/wave2-llms-compliance.spec.ts
+++ b/tests/unit/wave2-llms-compliance.spec.ts
@@ -22,7 +22,7 @@ describe('llms-feed', () => {
     expect(open).toContain('sovereign-ai-architecture');
   });
 
-  it('includes Wave 1 pillars in pocket and full docs', () => {
+  it('includes institutional pillars in pocket and full docs', () => {
     expect(buildPocketLlmsSummary()).toContain('dora-eu-ai-act-wealth');
     expect(buildOpenLlmsSummary()).toContain('stateless-edge-ingestion');
     expect(buildLlmsFullDocumentation()).toContain('stateless-edge-ingestion');


### PR DESCRIPTION
﻿## Summary
- Rewrite `/learn/enterprise-design-partnership` for institutional buyer voice (no Wave/BIP/blog-farm jargon)
- Remove PR #90 / crawl-budget language from stateless-edge-ingestion pillar
- Soften sovereign-ai-architecture copy for CISO-facing tone
- De-jargon `llms.txt` feeds ("Institutional Architecture Briefs")
- Route enterprise CTA to Tier 1 Design Partnership (not Board of Investors)
- Clean Open contact form labels and remove internal `/admin/analytics` reference

## Test plan
- [x] `npm run build:llms`
- [x] `npx vitest run tests/unit/wave2-llms-compliance.spec.ts`
- [ ] Verify https://www.openportfolio.co.uk/learn/enterprise-design-partnership after deploy
