### PR TITLE
Open /learn hub: institutional pillars, not Pocket glossary

### DIFF
--- a/app/open/_components/OpenFooter.tsx
+++ b/app/open/_components/OpenFooter.tsx
@@ -57,17 +57,8 @@ export default async function OpenFooter() {
               {pathway.label}
             </Link>
           ))}
-          <Link
-            href="/learn/sovereign-stack"
-            style={{ color: 'inherit', textDecoration: 'none', opacity: 0.72 }}
-          >
-            Sovereign Stack
-          </Link>
-          <Link
-            href="/learn/local-first"
-            style={{ color: 'inherit', textDecoration: 'none', opacity: 0.72 }}
-          >
-            Local-First
+          <Link href="/learn" style={{ color: 'inherit', textDecoration: 'none', opacity: 0.72 }}>
+            Architecture Briefs
           </Link>
           <a href={pocketHref} style={{ color: 'inherit', textDecoration: 'none' }}>
             {SURFACE_CROSS_LINKS.open.label}

--- a/app/open/learn/_components/OpenLearnHub.tsx
+++ b/app/open/learn/_components/OpenLearnHub.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  OPEN_INSTITUTIONAL_PILLARS,
+  OPEN_LEARN_HUB_COPY,
+  OPEN_LEARN_PHILOSOPHY,
+} from '@/lib/canonical-claims';
+
+type BriefCard = {
+  slug: string;
+  title: string;
+  summary: string;
+  category: string;
+  url: string;
+};
+
+function BriefCardLink({ brief, featured }: { brief: BriefCard; featured?: boolean }) {
+  return (
+    <Link
+      href={`/learn/${brief.slug}`}
+      style={{
+        background: 'var(--surface)',
+        border: featured ? '2px solid var(--accent-warm)' : '1px solid var(--border-subtle)',
+        borderRadius: '12px',
+        padding: featured ? '26px' : '22px',
+        textDecoration: 'none',
+        color: 'var(--text)',
+        transition: 'border-color 0.2s, transform 0.2s',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: featured ? '220px' : '180px',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = 'var(--accent-warm)';
+        e.currentTarget.style.transform = 'translateY(-2px)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = featured
+          ? 'var(--accent-warm)'
+          : 'var(--border-subtle)';
+        e.currentTarget.style.transform = 'translateY(0)';
+      }}
+    >
+      <span
+        style={{
+          display: 'inline-block',
+          padding: '4px 10px',
+          borderRadius: '4px',
+          fontSize: '11px',
+          fontWeight: 600,
+          background: 'color-mix(in srgb, var(--accent-warm) 12%, transparent)',
+          color: 'var(--accent-warm)',
+          marginBottom: '12px',
+          width: 'fit-content',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+        }}
+      >
+        {brief.category}
+      </span>
+      <h2
+        style={{
+          fontSize: featured ? '21px' : '18px',
+          fontWeight: 700,
+          marginBottom: '10px',
+          lineHeight: 1.3,
+        }}
+      >
+        {brief.title}
+      </h2>
+      <p
+        style={{
+          fontSize: '14px',
+          color: 'var(--text-secondary)',
+          lineHeight: 1.65,
+          margin: 0,
+          flexGrow: 1,
+        }}
+      >
+        {brief.summary}
+      </p>
+      <span
+        style={{
+          marginTop: '16px',
+          fontSize: '13px',
+          fontWeight: 600,
+          color: 'var(--accent-warm)',
+        }}
+      >
+        Read brief →
+      </span>
+    </Link>
+  );
+}
+
+export default function OpenLearnHub() {
+  return (
+    <div
+      style={{
+        maxWidth: '1080px',
+        margin: '0 auto',
+        padding: 'clamp(24px, 5vw, 48px) clamp(16px, 4vw, 32px)',
+      }}
+    >
+      <header style={{ marginBottom: '40px', maxWidth: '760px' }}>
+        <p
+          style={{
+            margin: '0 0 12px',
+            fontSize: '12px',
+            fontWeight: 600,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: 'var(--accent-warm)',
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          }}
+        >
+          Open Portfolio · Learn
+        </p>
+        <h1
+          style={{
+            fontSize: 'clamp(30px, 5vw, 44px)',
+            fontWeight: 800,
+            color: 'var(--text)',
+            marginBottom: '14px',
+            lineHeight: 1.15,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {OPEN_LEARN_HUB_COPY.title}
+        </h1>
+        <p
+          style={{
+            fontSize: 'clamp(16px, 2vw, 18px)',
+            color: 'var(--text-secondary)',
+            lineHeight: 1.65,
+            margin: 0,
+          }}
+        >
+          {OPEN_LEARN_HUB_COPY.subtitle}
+        </p>
+      </header>
+
+      <section aria-labelledby="institutional-pillars-heading" style={{ marginBottom: '48px' }}>
+        <h2
+          id="institutional-pillars-heading"
+          style={{
+            fontSize: '13px',
+            fontWeight: 600,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--text-secondary)',
+            marginBottom: '18px',
+          }}
+        >
+          Primary briefs
+        </h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+            gap: '20px',
+          }}
+        >
+          {OPEN_INSTITUTIONAL_PILLARS.map((brief) => (
+            <BriefCardLink key={brief.slug} brief={brief} featured />
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="philosophy-heading" style={{ marginBottom: '48px' }}>
+        <h2
+          id="philosophy-heading"
+          style={{
+            fontSize: '13px',
+            fontWeight: 600,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--text-secondary)',
+            marginBottom: '18px',
+          }}
+        >
+          {OPEN_LEARN_HUB_COPY.philosophyHeading}
+        </h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+            gap: '16px',
+          }}
+        >
+          {OPEN_LEARN_PHILOSOPHY.map((brief) => (
+            <BriefCardLink key={brief.slug} brief={brief} />
+          ))}
+        </div>
+      </section>
+
+      <section
+        style={{
+          border: '1px solid color-mix(in srgb, var(--accent-warm) 35%, transparent)',
+          borderRadius: '12px',
+          padding: '32px',
+          background: 'color-mix(in srgb, var(--accent-warm) 6%, var(--surface))',
+          textAlign: 'center',
+        }}
+      >
+        <h2 style={{ fontSize: '22px', fontWeight: 700, marginBottom: '10px' }}>
+          {OPEN_LEARN_HUB_COPY.ctaTitle}
+        </h2>
+        <p
+          style={{
+            fontSize: '15px',
+            color: 'var(--text-secondary)',
+            marginBottom: '22px',
+            lineHeight: 1.6,
+            maxWidth: '560px',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+          }}
+        >
+          {OPEN_LEARN_HUB_COPY.ctaBody}
+        </p>
+        <div style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <Link
+            href={OPEN_LEARN_HUB_COPY.ctaPrimaryHref}
+            style={{
+              display: 'inline-block',
+              background: 'var(--accent-warm)',
+              color: 'var(--text-warm, #1a1208)',
+              padding: '12px 22px',
+              borderRadius: '8px',
+              fontSize: '15px',
+              fontWeight: 700,
+              textDecoration: 'none',
+            }}
+          >
+            {OPEN_LEARN_HUB_COPY.ctaPrimaryLabel}
+          </Link>
+          <Link
+            href={OPEN_LEARN_HUB_COPY.ctaSecondaryHref}
+            style={{
+              display: 'inline-block',
+              border: '2px solid var(--accent-warm)',
+              color: 'var(--accent-warm)',
+              padding: '12px 22px',
+              borderRadius: '8px',
+              fontSize: '15px',
+              fontWeight: 700,
+              textDecoration: 'none',
+              background: 'transparent',
+            }}
+          >
+            {OPEN_LEARN_HUB_COPY.ctaSecondaryLabel}
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/open/learn/layout.tsx
+++ b/app/open/learn/layout.tsx
@@ -2,11 +2,14 @@ import type { Metadata } from 'next';
 import { OPEN_URLS, SURFACE_ORG } from '../../../lib/canonical-claims';
 
 export const metadata: Metadata = {
-  title: `Learn · ${SURFACE_ORG.open.name}`,
-  description: `Sovereign finance concepts for builders and institutions — ${SURFACE_ORG.open.name}.`,
+  title: `Institutional Architecture Briefs · ${SURFACE_ORG.open.name}`,
+  description:
+    'Published architecture briefs for CTOs and CISOs — sovereign AI, DORA/EU AI Act, edge ingestion, and enterprise design partnership.',
   alternates: { canonical: OPEN_URLS.learnHub },
   openGraph: {
-    title: `Learn | ${SURFACE_ORG.open.name}`,
+    title: `Institutional Architecture Briefs | ${SURFACE_ORG.open.name}`,
+    description:
+      'Sovereign ingestion and stateless inference doctrine for regulated wealth-tech platforms.',
     url: OPEN_URLS.learnHub,
     siteName: SURFACE_ORG.open.name,
     type: 'website',

--- a/app/open/learn/page.tsx
+++ b/app/open/learn/page.tsx
@@ -1,1 +1,5 @@
-export { default } from '../../learn/page';
+import OpenLearnHub from './_components/OpenLearnHub';
+
+export default function OpenLearnPage() {
+  return <OpenLearnHub />;
+}

--- a/lib/canonical-claims.ts
+++ b/lib/canonical-claims.ts
@@ -647,6 +647,84 @@ export const OPEN_URLS = {
   sitemap: 'https://www.openportfolio.co.uk/sitemap.xml',
 } as const;
 
+/** Institutional architecture briefs — primary Open /learn hub (CTO/CISO-facing). */
+export const OPEN_INSTITUTIONAL_PILLARS = [
+  {
+    slug: 'sovereign-ai-architecture',
+    title: 'Sovereign AI Architecture & Data Perimeters',
+    summary:
+      'Local-first ingestion, stateless inference, and architectural data perimeters for wealth-tech platforms that cannot warehouse client ledgers.',
+    category: 'Architecture',
+    url: OPEN_URLS.sovereignAiArchitecture,
+  },
+  {
+    slug: 'dora-eu-ai-act-wealth',
+    title: 'DORA & EU AI Act for Wealth Management',
+    summary:
+      'Operational resilience and AI governance mapped to edge ingestion — reduce ICT blast radius without a central data lake.',
+    category: 'Compliance',
+    url: OPEN_URLS.doraEuAiActWealth,
+  },
+  {
+    slug: 'stateless-edge-ingestion',
+    title: 'Stateless Edge Ingestion vs Centralized Warehousing',
+    summary:
+      'Economics and liability of edge ingestion versus centralized wealth-tech data lakes.',
+    category: 'Economics',
+    url: OPEN_URLS.statelessEdgeIngestion,
+  },
+  {
+    slug: 'enterprise-design-partnership',
+    title: 'Enterprise Design Partnership Program',
+    summary:
+      'Limited-capacity design partnership for platforms building sovereign ingestion and inference into regulated stacks.',
+    category: 'Partnership',
+    url: OPEN_URLS.enterpriseDesignPartnership,
+  },
+] as const;
+
+/** Secondary philosophy briefs on Open /learn — not retail glossary entries. */
+export const OPEN_LEARN_PHILOSOPHY = [
+  {
+    slug: 'sovereign-stack',
+    title: 'The Sovereign Stack',
+    summary:
+      'Client-side analysis architecture where sensitive banking data never becomes a platform-hosted net-worth warehouse.',
+    category: 'Architecture',
+    url: OPEN_URLS.sovereignStack,
+  },
+  {
+    slug: 'local-first',
+    title: 'Local-First Architecture',
+    summary:
+      'Data stored and processed on the operator device first — privacy, offline resilience, and audit perimeter by design.',
+    category: 'Architecture',
+    url: OPEN_URLS.localFirst,
+  },
+  {
+    slug: 'vendor-lock-in',
+    title: 'Vendor Lock-In',
+    summary:
+      'Why proprietary formats expand switching cost — and how open ingestion boundaries prevent capture.',
+    category: 'Philosophy',
+    url: OPEN_URLS.vendorLockIn,
+  },
+] as const;
+
+export const OPEN_LEARN_HUB_COPY = {
+  title: 'Institutional Architecture Briefs',
+  subtitle:
+    'Published doctrine for CTOs, CISOs, and platform operators evaluating sovereign ingestion and stateless inference.',
+  philosophyHeading: 'Foundational concepts',
+  ctaTitle: 'Ready for a diligence conversation?',
+  ctaBody:
+    'Start with the Tier 1 design brief or contact the team with your audit-perimeter requirements.',
+  ctaPrimaryLabel: 'Explore Design Partnership',
+  ctaPrimaryHref: '/tier1designpartner',
+  ctaSecondaryLabel: 'Read full architecture',
+  ctaSecondaryHref: '/architecture',
+} as const;
+
 /**
  * Developer + institutional routes with thin-wrapper aliases on the O. surface.
  * Pocket→Open 301 matrix: `next.config.js` (`OPEN_ALIAS_POCKET_TO_OPEN_PATHS`) — same paths except `/press`
@@ -748,6 +826,7 @@ export interface SurfaceNavItem {
  * Institutional tracks (Design Challenge, Tier 1, BIP) live in footer pathways.
  */
 export const OPEN_NAV: ReadonlyArray<SurfaceNavItem> = [
+  { label: 'Learn', href: '/learn' },
   { label: 'Architecture', href: '/architecture' },
   { label: 'Blog', href: '/blog' },
 ] as const;

--- a/lib/llms-feed.ts
+++ b/lib/llms-feed.ts
@@ -10,6 +10,7 @@ import {
   LAST_HUMAN_VERIFIED,
   NUMBERS_SNAPSHOT,
   OPEN_ALIAS_ROUTES,
+  OPEN_INSTITUTIONAL_PILLARS,
   OPEN_URLS,
   ORG,
   PACKAGES,
@@ -24,31 +25,12 @@ import {
 
 const generatedAt = `${LAST_HUMAN_VERIFIED}T00:00:00Z`;
 
-const INSTITUTIONAL_PILLARS = [
-  {
-    title: 'Sovereign AI Architecture & Data Perimeters',
-    url: OPEN_URLS.sovereignAiArchitecture,
-  },
-  {
-    title: 'DORA & EU AI Act for Wealth Management',
-    url: OPEN_URLS.doraEuAiActWealth,
-  },
-  {
-    title: 'Stateless Edge Ingestion',
-    url: OPEN_URLS.statelessEdgeIngestion,
-  },
-  {
-    title: 'Enterprise Design Partnership',
-    url: OPEN_URLS.enterpriseDesignPartnership,
-  },
-] as const;
-
 function packagesSection(): string {
   return PACKAGES.map((pkg) => `- ${pkg.name} — ${pkg.description}`).join('\n');
 }
 
 function institutionalPillarsSection(): string {
-  return INSTITUTIONAL_PILLARS.map((p) => `- [${p.title}](${p.url})`).join('\n');
+  return OPEN_INSTITUTIONAL_PILLARS.map((p) => `- [${p.title}](${p.url})`).join('\n');
 }
 
 /** Pocket Portfolio summary feed (consumer + developer context). */

--- a/tests/unit/open-learn-hub.spec.ts
+++ b/tests/unit/open-learn-hub.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  OPEN_INSTITUTIONAL_PILLARS,
+  OPEN_LEARN_HUB_COPY,
+  OPEN_NAV,
+  OPEN_URLS,
+} from '@/lib/canonical-claims';
+
+describe('Open Learn hub (enterprise gateway)', () => {
+  it('defines four institutional pillars as SSOT', () => {
+    expect(OPEN_INSTITUTIONAL_PILLARS).toHaveLength(4);
+    const slugs = OPEN_INSTITUTIONAL_PILLARS.map((p) => p.slug);
+    expect(slugs).toEqual([
+      'sovereign-ai-architecture',
+      'dora-eu-ai-act-wealth',
+      'stateless-edge-ingestion',
+      'enterprise-design-partnership',
+    ]);
+  });
+
+  it('uses institutional hub copy — not Pocket glossary framing', () => {
+    expect(OPEN_LEARN_HUB_COPY.title).toContain('Institutional Architecture');
+    expect(OPEN_LEARN_HUB_COPY.title.toLowerCase()).not.toContain('glossary');
+    expect(OPEN_LEARN_HUB_COPY.ctaPrimaryHref).toBe('/tier1designpartner');
+  });
+
+  it('Open nav includes Learn entry point', () => {
+    expect(OPEN_NAV.some((item) => item.href === '/learn')).toBe(true);
+  });
+
+  it('Open learn page does not re-export Pocket glossary', () => {
+    const pagePath = resolve(process.cwd(), 'app/open/learn/page.tsx');
+    const source = readFileSync(pagePath, 'utf8');
+    expect(source).not.toContain("../../learn/page");
+    expect(source).toContain('OpenLearnHub');
+  });
+
+  it('pillar URLs match Open canonical learn paths', () => {
+    for (const pillar of OPEN_INSTITUTIONAL_PILLARS) {
+      expect(pillar.url).toBe(`${OPEN_URLS.learnHub}/${pillar.slug}`);
+    }
+  });
+});

--- a/tests/unit/open-sitemap.spec.ts
+++ b/tests/unit/open-sitemap.spec.ts
@@ -11,6 +11,15 @@ describe('openSitemapStatic', () => {
     expect(urls).toContain(OPEN_URLS.home);
     expect(urls).toContain(`${OPEN_URLS.home}/blog`);
     expect(urls).toContain(OPEN_URLS.architecture);
+    for (const pillar of [
+      OPEN_URLS.sovereignAiArchitecture,
+      OPEN_URLS.doraEuAiActWealth,
+      OPEN_URLS.statelessEdgeIngestion,
+      OPEN_URLS.enterpriseDesignPartnership,
+    ]) {
+      expect(urls).toContain(pillar);
+    }
+    expect(urls).toContain(OPEN_URLS.learnHub);
 
     const { open } = partitionBlogPostsForSitemap(loadBlogPostSitemapEntries());
     for (const post of open.slice(0, 5)) {


### PR DESCRIPTION
## Summary
- Replace Open `/learn` re-export of Pocket retail glossary with `OpenLearnHub`
- Primary: 4 institutional architecture briefs (SSOT in `canonical-claims.ts`)
- Secondary: sovereign-stack, local-first, vendor-lock-in philosophy briefs
- Add **Learn** to Open nav; footer links Architecture Briefs hub
- CI gate: `tests/unit/open-learn-hub.spec.ts` asserts hub does not re-export Pocket page

## Test plan
- [x] vitest open-learn-hub + open-sitemap + canonical-claims + llms-feed
- [ ] After deploy: https://www.openportfolio.co.uk/learn shows 4 pillars, not Portfolio Beta