### PR TITLE
Admin analytics: track only cron-allowed deep-dive posts

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -93,6 +93,8 @@ interface AnalyticsData {
     pending: number;
     overdue: number;
     failed: number;
+    farmPaused?: boolean;
+    scope?: string;
     posts: Array<{
       id: string;
       title: string;
@@ -102,7 +104,7 @@ interface AnalyticsData {
       scheduledTime: string | null;
       status: 'pending' | 'published' | 'failed';
       pillar: string;
-      category?: string; // ✅ ADD CATEGORY
+      category?: string;
       isOverdue: boolean;
       hasFiles: boolean;
       publishedTime: string | null;
@@ -1845,11 +1847,21 @@ export default function AdminAnalyticsPage() {
             <h2 style={{
               fontSize: '20px',
               fontWeight: 'bold',
-              marginBottom: 'var(--space-4)',
+              marginBottom: 'var(--space-2)',
               color: 'var(--text)'
             }}>
-              📝 Blog Posts (Autonomous Engine)
+              Blog Posts (Allowed Autonomous Queue)
             </h2>
+            <p style={{
+              fontSize: '13px',
+              color: 'var(--text-secondary)',
+              marginBottom: 'var(--space-4)',
+              lineHeight: 1.5,
+            }}>
+              {analyticsData.blogPosts.farmPaused !== false
+                ? 'Wave 1 farm pause active — tracking deep-dive posts only (how-to / research calendars hidden until OP_BLOG_FARM_PAUSED=false).'
+                : 'Farm pause off — tracking all calendars eligible for the autonomous cron.'}
+            </p>
 
             {/* Summary Metrics */}
             <div style={{
@@ -1859,9 +1871,9 @@ export default function AdminAnalyticsPage() {
               marginBottom: 'var(--space-4)'
             }}>
               <MetricCard
-                label="Total Posts"
+                label="Total Allowed"
                 value={analyticsData.blogPosts.total.toString()}
-                subtitle="Scheduled"
+                subtitle={analyticsData.blogPosts.scope === 'deep-dive-only' ? 'Deep-dive queue' : 'Scheduled'}
               />
               <MetricCard
                 label="Published"
@@ -1871,12 +1883,12 @@ export default function AdminAnalyticsPage() {
               <MetricCard
                 label="Pending"
                 value={analyticsData.blogPosts.pending.toString()}
-                subtitle="Scheduled"
+                subtitle="In queue"
               />
               <MetricCard
                 label="Overdue"
                 value={analyticsData.blogPosts.overdue.toString()}
-                subtitle={analyticsData.blogPosts.overdue > 0 ? "⚠️ Action needed" : "All on track"}
+                subtitle={analyticsData.blogPosts.overdue > 0 ? "Action needed" : "All on track"}
               />
             </div>
 
@@ -1957,27 +1969,15 @@ export default function AdminAnalyticsPage() {
                           <span style={{
                             fontSize: '12px',
                             padding: '4px 8px',
-                            background: post.category === 'how-to-in-tech' 
-                              ? 'rgba(34, 197, 94, 0.1)' 
-                              : post.category === 'research'
-                              ? 'rgba(59, 130, 246, 0.1)'
-                              : 'var(--surface-elevated)',
-                            color: post.category === 'how-to-in-tech' 
-                              ? '#22c55e' 
-                              : post.category === 'research'
-                              ? '#3b82f6'
-                              : 'var(--text)',
+                            background: 'color-mix(in srgb, var(--accent-warm) 12%, transparent)',
+                            color: 'var(--accent-warm)',
                             borderRadius: '4px',
                             fontWeight: '600',
-                            border: post.category === 'how-to-in-tech' 
-                              ? '1px solid #22c55e' 
-                              : post.category === 'research'
-                              ? '1px solid #3b82f6'
-                              : '1px solid var(--border)'
+                            border: '1px solid color-mix(in srgb, var(--accent-warm) 35%, transparent)'
                           }}>
-                            {post.category === 'how-to-in-tech' ? '📝 How to' : 
-                             post.category === 'research' ? '🔬 Research' : 
-                             '📚 Deep Dive'}
+                            {post.category === 'how-to-in-tech' ? 'How to' :
+                             post.category === 'research' ? 'Research' :
+                             'Deep Dive'}
                           </span>
                         </td>
                         <td style={{ padding: '12px', color: 'var(--text-secondary)' }}>
@@ -2038,8 +2038,8 @@ export default function AdminAnalyticsPage() {
                 borderRadius: '8px',
                 color: '#f59e0b'
               }}>
-                <strong>⚠️ Warning:</strong> {analyticsData.blogPosts.overdue} post(s) are overdue. 
-                The health check workflow should auto-trigger generation. Check GitHub Actions if posts don't appear.
+                <strong>Warning:</strong> {analyticsData.blogPosts.overdue} allowed post(s) are overdue.
+                Check Vercel Cron for <code>/api/cron/generate-blog</code> if deep-dives do not publish.
               </div>
             )}
           </section>

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -15,6 +15,10 @@ import {
   shouldDegradeFirestoreReads,
 } from '@/app/lib/server/firestore-quota-circuit';
 import { getLandingAbCohortPerformance } from '@/lib/admin/landing-ab-cohort';
+import {
+  isBlogFarmPaused,
+  isCronEligibleBlogCategory,
+} from '@/lib/blog-generator-cron';
 
 // Force dynamic rendering for API route
 export const dynamic = 'force-dynamic';
@@ -227,7 +231,15 @@ export async function GET(request: NextRequest) {
     // Fetch blog posts data
     console.log('[Analytics API] 📝 Fetching blog posts data...');
         const blogPosts = await getBlogPostsData();
-        console.log('[Analytics API] ✅ Blog posts fetched:', blogPosts.total, 'total posts,', blogPosts.posts.filter((p: any) => p.category === 'research').length, 'research posts');
+        console.log(
+          '[Analytics API] Blog posts fetched:',
+          blogPosts.total,
+          'allowed,',
+          'scope=',
+          blogPosts.scope,
+          'farmPaused=',
+          blogPosts.farmPaused,
+        );
     
     // Fetch leads data
     console.log('[Analytics API] 👥 Fetching leads data...');
@@ -1566,191 +1578,75 @@ async function getNPMData() {
 }
 
 async function getBlogPostsData() {
-  console.log('[getBlogPostsData] 🚀 Starting blog posts data fetch');
-  console.log('[getBlogPostsData] 📂 Current working directory:', process.cwd());
+  console.log('[getBlogPostsData] Starting blog posts data fetch (cron-eligible only)');
   try {
-    // ✅ Load main calendar (deep dives)
+    const farmPaused = isBlogFarmPaused();
     const mainCalendarPath = path.join(process.cwd(), 'content', 'blog-calendar.json');
-    console.log('[getBlogPostsData] 📂 Loading main calendar from:', mainCalendarPath);
-    console.log('[getBlogPostsData] 📂 Main calendar file exists?', fs.existsSync(mainCalendarPath));
+    const howToCalendarPath = path.join(process.cwd(), 'content', 'how-to-tech-calendar.json');
+    const researchCalendarPath = path.join(process.cwd(), 'content', 'research-calendar.json');
+
     const mainCalendar = fs.existsSync(mainCalendarPath)
       ? JSON.parse(fs.readFileSync(mainCalendarPath, 'utf-8'))
       : [];
-    console.log('[getBlogPostsData] ✅ Loaded', mainCalendar.length, 'main calendar posts');
+    const howToCalendar =
+      !farmPaused && fs.existsSync(howToCalendarPath)
+        ? JSON.parse(fs.readFileSync(howToCalendarPath, 'utf-8'))
+        : [];
+    const researchCalendar =
+      !farmPaused && fs.existsSync(researchCalendarPath)
+        ? JSON.parse(fs.readFileSync(researchCalendarPath, 'utf-8'))
+        : [];
 
-    // ✅ Load "How to in Tech" calendar (daily posts)
-    const howToCalendarPath = path.join(process.cwd(), 'content', 'how-to-tech-calendar.json');
-    console.log('[getBlogPostsData] 📂 Loading how-to calendar from:', howToCalendarPath);
-    console.log('[getBlogPostsData] 📂 How-to calendar file exists?', fs.existsSync(howToCalendarPath));
-    const howToCalendar = fs.existsSync(howToCalendarPath)
-      ? JSON.parse(fs.readFileSync(howToCalendarPath, 'utf-8'))
-      : [];
-    console.log('[getBlogPostsData] ✅ Loaded', howToCalendar.length, 'how-to calendar posts');
-
-    // ✅ Load "Research" calendar (research posts)
-    const researchCalendarPath = path.join(process.cwd(), 'content', 'research-calendar.json');
-    console.log('[getBlogPostsData] 📂 Loading research calendar from:', researchCalendarPath);
-    console.log('[getBlogPostsData] 📂 Research calendar file exists?', fs.existsSync(researchCalendarPath));
-    let researchCalendar: any[] = [];
-    if (fs.existsSync(researchCalendarPath)) {
-      try {
-        const researchCalendarContent = fs.readFileSync(researchCalendarPath, 'utf-8');
-        researchCalendar = JSON.parse(researchCalendarContent);
-        console.log(`[Analytics] ✅ Loaded ${researchCalendar.length} research posts from calendar`);
-      } catch (error: any) {
-        console.error('[Analytics] ❌ Error loading research calendar:', error.message);
-        console.error('[Analytics] ❌ Error stack:', error.stack);
-        researchCalendar = [];
-      }
-    } else {
-      console.warn('[Analytics] ⚠️ Research calendar file not found:', researchCalendarPath);
-      console.warn('[Analytics] ⚠️ Current working directory:', process.cwd());
-    }
-
-    // ✅ CRITICAL FIX: Filter out research posts from mainCalendar to prevent overwrites
-    // Research posts should ONLY come from research-calendar.json
+    // Deep-dives only while farm paused (matches /api/cron/generate-blog allowlist).
     const mainCalendarFiltered = mainCalendar.filter((p: any) => {
-      // Exclude posts that are explicitly marked as research OR have research slugs
-      const isResearch = p.category === 'research' || 
-                        (p.slug && p.slug.startsWith('research-')) ||
-                        (p.id && p.id.startsWith('research-'));
-      return !isResearch;
+      const isResearch =
+        p.category === 'research' ||
+        (p.slug && String(p.slug).startsWith('research-')) ||
+        (p.id && String(p.id).startsWith('research-'));
+      if (isResearch) return false;
+      return isCronEligibleBlogCategory(p.category || 'deep-dive');
     });
-    // ✅ Merge calendars (mark posts with category and source)
-    const calendar = [
-      ...mainCalendarFiltered.map((p: any) => ({ ...p, category: p.category || 'deep-dive', _source: 'main' })),
-      ...howToCalendar.map((p: any) => ({ ...p, category: 'how-to-in-tech', _source: 'how-to' })),
-      ...researchCalendar.map((p: any) => ({ ...p, category: 'research', _source: 'research-calendar' }))
-    ];
-    console.log(`[Analytics] 📊 Total posts after merge: ${calendar.length} (main: ${mainCalendarFiltered.length}, how-to: ${howToCalendar.length}, research: ${researchCalendar.length})`);
-    console.log(`[Analytics] 🔍 Filtered ${mainCalendar.length - mainCalendarFiltered.length} research posts from main calendar`);
 
-    // ✅ Deduplicate posts by ID (for research) or slug (for others)
-    // Research posts can have duplicate slugs (same topic, different dates), so use ID as key
-    // Other posts use slug as key (unique per post)
+    const calendar = [
+      ...mainCalendarFiltered.map((p: any) => ({
+        ...p,
+        category: p.category || 'deep-dive',
+        _source: 'main',
+      })),
+      ...howToCalendar.map((p: any) => ({
+        ...p,
+        category: 'how-to-in-tech',
+        _source: 'how-to',
+      })),
+      ...researchCalendar.map((p: any) => ({
+        ...p,
+        category: 'research',
+        _source: 'research-calendar',
+      })),
+    ].filter((p: any) => isCronEligibleBlogCategory(p.category));
+
     const postMap = new Map<string, any>();
-    let duplicateCount = 0;
-    let researchDuplicates = 0;
-    let researchReplaced = 0;
-    let researchSkipped = 0;
-    
-    // Helper function to get the deduplication key for a post
-    const getPostKey = (post: any): string => {
-      // Research posts use ID (unique, includes date) to handle duplicate slugs
-      if (post.category === 'research' && post.id) {
-        return post.id;
-      }
-      // Other posts use slug
-      return post.slug || post.id || `unknown-${Math.random()}`;
-    };
-    
-    // CRITICAL: Process research-calendar.json posts FIRST to ensure they always win
-    // Separate research posts from research-calendar.json and process them first
-    const researchCalendarPosts = calendar.filter((p: any) => p._source === 'research-calendar');
-    const otherPosts = calendar.filter((p: any) => p._source !== 'research-calendar');
-    
-    // First pass: Add all research-calendar.json posts to map (they win by default)
-    for (const post of researchCalendarPosts) {
-      const key = getPostKey(post);
+    for (const post of calendar) {
+      const key =
+        post.category === 'research' && post.id
+          ? post.id
+          : post.slug || post.id || `unknown-${Math.random()}`;
       const existing = postMap.get(key);
       if (!existing) {
         postMap.set(key, post);
-      } else {
-        // Shouldn't happen in first pass for research posts (IDs are unique), but handle it
-        duplicateCount++;
-        researchDuplicates++;
-        postMap.set(key, post);
-        researchReplaced++;
+        continue;
       }
-    }
-    
-    // Second pass: Process other posts, but never replace research-calendar posts
-    for (const post of otherPosts) {
-      const key = getPostKey(post);
-      const existing = postMap.get(key);
-      if (!existing) {
+      if (post.status === 'published' && existing.status !== 'published') {
         postMap.set(key, post);
-      } else {
-        duplicateCount++;
-        // CRITICAL: Never replace research posts from research-calendar.json
-        if (existing._source === 'research-calendar' && existing.category === 'research') {
-          // Existing is from research-calendar.json - keep it, skip this one
-          researchSkipped++;
-          continue;
-        } else if (post.category === 'research' && existing.category !== 'research') {
-          // New post is research (but not from research-calendar), existing is not - prefer research
-          postMap.set(key, post);
-          researchReplaced++;
-        } else if (post.category === 'research' && existing.category === 'research') {
-          // Both are research, but existing is from research-calendar.json (already processed) - keep existing
-          researchSkipped++;
-          continue;
-        } else {
-          // Prefer published over pending
-          if (post.status === 'published' && existing.status !== 'published') {
-            postMap.set(key, post);
-          } else if (post.status === existing.status) {
-            // If same status, prefer the one with files or newer date
-            const postSlug = post.slug || post.id;
-            const existingSlug = existing.slug || existing.id;
-            const postHasFiles = fs.existsSync(path.join(process.cwd(), 'content', 'posts', `${postSlug}.mdx`));
-            const existingHasFiles = fs.existsSync(path.join(process.cwd(), 'content', 'posts', `${existingSlug}.mdx`));
-            if (postHasFiles && !existingHasFiles) {
-              postMap.set(key, post);
-            } else if (post.date > existing.date) {
-              postMap.set(key, post);
-            }
-          }
-        }
+      } else if (post.status === existing.status && post.date > existing.date) {
+        postMap.set(key, post);
       }
     }
     const deduplicatedCalendar = Array.from(postMap.values());
-    
-    // ✅ Comprehensive category and pillar tracking verification
-    const categoryBreakdown = {
-      'deep-dive': deduplicatedCalendar.filter((p: any) => p.category === 'deep-dive' || (!p.category && p._source === 'main')).length,
-      'how-to-in-tech': deduplicatedCalendar.filter((p: any) => p.category === 'how-to-in-tech').length,
-      'research': deduplicatedCalendar.filter((p: any) => p.category === 'research').length,
-    };
-    const pillarBreakdown = {
-      'philosophy': deduplicatedCalendar.filter((p: any) => p.pillar === 'philosophy').length,
-      'technical': deduplicatedCalendar.filter((p: any) => p.pillar === 'technical').length,
-      'market': deduplicatedCalendar.filter((p: any) => p.pillar === 'market').length,
-      'product': deduplicatedCalendar.filter((p: any) => p.pillar === 'product').length,
-      'unknown': deduplicatedCalendar.filter((p: any) => !p.pillar).length,
-    };
-    const sourceBreakdown = {
-      'main': deduplicatedCalendar.filter((p: any) => p._source === 'main').length,
-      'how-to': deduplicatedCalendar.filter((p: any) => p._source === 'how-to').length,
-      'research-calendar': deduplicatedCalendar.filter((p: any) => p._source === 'research-calendar').length,
-    };
-    
-    console.log(`[Analytics] 🔄 After deduplication: ${deduplicatedCalendar.length} posts (removed ${duplicateCount} duplicates)`);
-    console.log(`[Analytics] 📊 Category breakdown:`, categoryBreakdown);
-    console.log(`[Analytics] 🏛️ Pillar breakdown:`, pillarBreakdown);
-    console.log(`[Analytics] 📁 Source breakdown:`, sourceBreakdown);
-    
-    // Log research posts count
-    const researchPostsCount = deduplicatedCalendar.filter((p: any) => p.category === 'research').length;
-    console.log(`[Analytics] 🔬 Research posts in final calendar: ${researchPostsCount}`);
-    
-    // ✅ Log date range for diagnosis
-    const researchPosts = deduplicatedCalendar.filter((p: any) => p.category === 'research');
-    if (researchPosts.length > 0) {
-      const dates = researchPosts.map((p: any) => p.date).sort();
-      const earliestDate = dates[0];
-      const latestDate = dates[dates.length - 1];
-      const janCount = dates.filter((d: string) => d.startsWith('2026-01')).length;
-      const augCount = dates.filter((d: string) => d.startsWith('2026-08')).length;
-      console.log(`[Analytics] 📅 Research posts date range: ${earliestDate} to ${latestDate}`);
-      console.log(`[Analytics] 📊 Research posts by month: Jan=${janCount}, Aug=${augCount}, Total=${dates.length}`);
-    }
 
     const today = new Date().toISOString().split('T')[0];
     const todayDate = new Date(today);
     const isVercel = typeof process.env.VERCEL === 'string';
-
-    // Check which posts have actual files (only possible when filesystem is available, e.g. local/build)
     const postsDir = path.join(process.cwd(), 'content', 'posts');
     const imagesDir = path.join(process.cwd(), 'public', 'images', 'blog');
 
@@ -1758,38 +1654,22 @@ async function getBlogPostsData() {
       const mdxPath = path.join(postsDir, `${post.slug}.mdx`);
       const imagePath = path.join(imagesDir, `${post.slug}.png`);
 
-      // On Vercel serverless, content/posts and public/images/blog are not in the function bundle,
-      // so fs checks always fail. Infer from calendar: published + date <= today => assume files deployed.
       let hasFiles = false;
       if (isVercel) {
         hasFiles = post.status === 'published' && new Date(post.date) <= todayDate;
       } else {
         try {
-          const mdxExists = fs.existsSync(mdxPath);
-          const imageExists = fs.existsSync(imagePath);
-          hasFiles = mdxExists && imageExists;
-          if (!hasFiles && post.category === 'research' && post.status === 'published') {
-            console.warn(`[Analytics] Research post files missing: ${post.slug}`, {
-              mdxPath, imagePath, mdxExists, imageExists,
-              postsDirExists: fs.existsSync(postsDir),
-              imagesDirExists: fs.existsSync(imagesDir),
-              cwd: process.cwd(),
-            });
-          }
-        } catch (error: any) {
-          console.error(`[Analytics] Error checking files for ${post.slug}:`, error.message);
+          hasFiles = fs.existsSync(mdxPath) && fs.existsSync(imagePath);
+        } catch {
           hasFiles = false;
         }
       }
 
       const postDate = new Date(post.date);
-      // If we inferred hasFiles from calendar (Vercel), effectiveStatus is already post.status for published
-      const effectiveStatus = !isVercel && hasFiles && postDate <= todayDate
-        ? 'published'
-        : post.status;
+      const effectiveStatus =
+        !isVercel && hasFiles && postDate <= todayDate ? 'published' : post.status;
       const isOverdue = postDate < todayDate && effectiveStatus === 'pending';
 
-      // Published time: from calendar (publishedAt), file mtime (local), or scheduled time when published
       const scheduledDateTime = post.scheduledTime
         ? `${post.date}T${post.scheduledTime}:00Z`
         : `${post.date}T00:00:00Z`;
@@ -1808,7 +1688,7 @@ async function getBlogPostsData() {
           publishedTime = scheduledDateTime;
         }
       }
-      
+
       return {
         id: post.id,
         title: post.title,
@@ -1816,13 +1696,17 @@ async function getBlogPostsData() {
         date: post.date,
         scheduledDate: post.date,
         scheduledTime: post.scheduledTime || null,
-        status: effectiveStatus, // ✅ Use effective status instead of calendar status
+        status: effectiveStatus,
         pillar: post.pillar,
-        category: post.category ?? 'deep-dive', // ✅ Preserve category (research, how-to-in-tech, or deep-dive)
+        category: post.category ?? 'deep-dive',
         isOverdue,
         hasFiles,
         publishedTime,
-        daysOverdue: isOverdue ? Math.floor((todayDate.getTime() - postDate.getTime()) / (1000 * 60 * 60 * 24)) : 0
+        daysOverdue: isOverdue
+          ? Math.floor(
+              (todayDate.getTime() - postDate.getTime()) / (1000 * 60 * 60 * 24),
+            )
+          : 0,
       };
     });
 
@@ -1830,25 +1714,25 @@ async function getBlogPostsData() {
     const pending = posts.filter((p: any) => p.status === 'pending').length;
     const overdue = posts.filter((p: any) => p.isOverdue).length;
     const failed = posts.filter((p: any) => p.status === 'failed').length;
-    // Note: Status counts now use effectiveStatus (auto-detected from file existence)
-    const researchPostsInFinal = posts.filter((p: any) => p.category === 'research').length;
 
-    const result = {
+    return {
       total: posts.length,
       published,
       pending,
       overdue,
       failed,
+      farmPaused,
+      scope: farmPaused
+        ? 'deep-dive-only'
+        : 'all-calendars',
       posts: posts.sort((a: any, b: any) => {
-        // Sort by date, then by status (overdue first)
         const dateCompare = new Date(a.date).getTime() - new Date(b.date).getTime();
         if (dateCompare !== 0) return dateCompare;
         if (a.isOverdue && !b.isOverdue) return -1;
         if (!a.isOverdue && b.isOverdue) return 1;
         return 0;
-      })
+      }),
     };
-    return result;
   } catch (error: any) {
     console.error('Error reading blog calendar:', error);
     return {
@@ -1857,8 +1741,10 @@ async function getBlogPostsData() {
       pending: 0,
       overdue: 0,
       failed: 0,
+      farmPaused: isBlogFarmPaused(),
+      scope: 'error',
       posts: [],
-      error: error.message
+      error: error.message,
     };
   }
 }

--- a/app/api/cron/generate-blog/route.ts
+++ b/app/api/cron/generate-blog/route.ts
@@ -4,6 +4,8 @@ import {
   getDuePosts,
   generatePostForCron,
   getCalendarFilePath,
+  isBlogFarmPaused,
+  isCronEligibleBlogCategory,
   type BlogPost,
 } from '@/lib/blog-generator-cron';
 
@@ -119,15 +121,10 @@ export async function GET(request: Request) {
     const calendar = await fetchCalendarsFromGitHub();
     const now = new Date();
     // Wave 1: pause how-to / research farm generation (set OP_BLOG_FARM_PAUSED=false to resume)
-    const farmPaused = process.env.OP_BLOG_FARM_PAUSED !== 'false';
-    const duePosts = getDuePosts(calendar, now).filter((p) => {
-      if (!farmPaused) return true;
-      const cat = p.category || '';
-      if (cat === 'how-to-in-tech' || cat === 'research') {
-        return false;
-      }
-      return true;
-    });
+    const farmPaused = isBlogFarmPaused();
+    const duePosts = getDuePosts(calendar, now).filter((p) =>
+      isCronEligibleBlogCategory(p.category),
+    );
 
     if (duePosts.length === 0) {
       return NextResponse.json({

--- a/lib/blog-generator-cron.ts
+++ b/lib/blog-generator-cron.ts
@@ -45,6 +45,20 @@ export interface BlogPost {
   publishedAt?: string;
 }
 
+/** Wave 1 farm pause — unset means paused. Set OP_BLOG_FARM_PAUSED=false to resume how-to/research. */
+export function isBlogFarmPaused(): boolean {
+  return process.env.OP_BLOG_FARM_PAUSED !== 'false';
+}
+
+/** Categories the autonomous cron may generate under the current farm policy. */
+export function isCronEligibleBlogCategory(
+  category: string | undefined | null,
+): boolean {
+  if (!isBlogFarmPaused()) return true;
+  const cat = category || 'deep-dive';
+  return cat !== 'how-to-in-tech' && cat !== 'research';
+}
+
 function parseScheduledTime(scheduledTime: string | undefined): { hour: number; minute: number; valid: boolean } {
   if (!scheduledTime || typeof scheduledTime !== 'string') return { hour: 0, minute: 0, valid: false };
   const trimmed = scheduledTime.trim();

--- a/tests/unit/blog-farm-allowlist.spec.ts
+++ b/tests/unit/blog-farm-allowlist.spec.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  isBlogFarmPaused,
+  isCronEligibleBlogCategory,
+} from '@/lib/blog-generator-cron';
+
+describe('blog farm allowlist (admin analytics + cron)', () => {
+  const original = process.env.OP_BLOG_FARM_PAUSED;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.OP_BLOG_FARM_PAUSED;
+    else process.env.OP_BLOG_FARM_PAUSED = original;
+  });
+
+  it('defaults farm pause ON when env unset', () => {
+    delete process.env.OP_BLOG_FARM_PAUSED;
+    expect(isBlogFarmPaused()).toBe(true);
+    expect(isCronEligibleBlogCategory('deep-dive')).toBe(true);
+    expect(isCronEligibleBlogCategory(undefined)).toBe(true);
+    expect(isCronEligibleBlogCategory('how-to-in-tech')).toBe(false);
+    expect(isCronEligibleBlogCategory('research')).toBe(false);
+  });
+
+  it('allows all categories when farm pause explicitly off', () => {
+    process.env.OP_BLOG_FARM_PAUSED = 'false';
+    expect(isBlogFarmPaused()).toBe(false);
+    expect(isCronEligibleBlogCategory('how-to-in-tech')).toBe(true);
+    expect(isCronEligibleBlogCategory('research')).toBe(true);
+    expect(isCronEligibleBlogCategory('deep-dive')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Admin `/admin/analytics` blog section now mirrors the Wave 1 farm pause: deep-dive only by default
- Shared helpers `isBlogFarmPaused` / `isCronEligibleBlogCategory` keep cron + analytics in sync
- UI copy clarifies allowed autonomous queue; overdue warning points at Vercel cron

## Test plan
- [x] vitest blog-farm-allowlist.spec.ts
- [ ] After deploy: /admin/analytics shows no Research / How-to Pending rows (InfluxDB / API Error Handling gone)
- [ ] Pending list is deep-dive only (next: Developer-First Portfolio Tool on 29 Jul)