### PR TITLE
Clean Open/Pocket blog surfaces and fix Open /book 404s

### DIFF
--- a/app/api/blog/posts/route.ts
+++ b/app/api/blog/posts/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
-import { isOpenBlogCategory, isPocketBlogCategory } from '@/lib/canonical-claims';
+import { isOpenBlogListingCategory, isPocketBlogCategory } from '@/lib/canonical-claims';
 
 // Disable caching to ensure fresh posts are always returned
 export const dynamic = 'force-dynamic';
@@ -106,8 +106,12 @@ export async function GET(request: NextRequest) {
     );
 
     // Presentation-only filter: cron still writes all MDX to content/posts.
+    // Open hub: institutional buyer briefs only (farm + internal SE serials out).
     if (surface === 'open') {
-      posts = posts.filter((p) => isOpenBlogCategory(p.category));
+      posts = posts.filter(
+        (p) =>
+          isOpenBlogListingCategory(p.category, p.slug) && !p.excludeFromLanding,
+      );
     } else if (surface === 'pocket') {
       posts = posts.filter((p) => isPocketBlogCategory(p.category));
     }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,7 +4,12 @@ import { notFound, redirect } from 'next/navigation';
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
-import { isOpenBlogCategory, OPEN_URLS, SURFACE_ORG, shouldNoindexOpenBlogFarm } from '@/lib/canonical-claims';
+import {
+  isOpenBlogCategory,
+  OPEN_URLS,
+  SURFACE_ORG,
+  shouldNoindexOpenBlogPost,
+} from '@/lib/canonical-claims';
 import { isNextNavigationError } from '@/lib/next-navigation-errors';
 import { isOpenPortfolioHost, openSurfaceBaseUrl, pocketSurfaceBaseUrl } from '@/lib/surface-host';
 import { escapeAngleBracketsInProse } from '@/lib/mdx-escape';
@@ -148,16 +153,15 @@ export async function generateMetadata({
   const brand = onOpen ? SURFACE_ORG.open.name : 'Pocket Portfolio';
   const fallbackOgImage = `${siteBase}/api/og?title=${encodeURIComponent(data.title)}&description=${encodeURIComponent(data.description || 'Sovereign Local-First Wealth Tracker')}&v=6`;
   const published = data.date ?? undefined;
-  const farmNoindex =
+  const openNoindex =
     data.noindex === true ||
-    (data.noindex !== false &&
-      shouldNoindexOpenBlogFarm(data.category, slug));
+    (data.noindex !== false && shouldNoindexOpenBlogPost(data.category, slug));
 
   return {
     title: `${data.title} | ${brand} Blog`,
     description: data.description,
     keywords: data.tags,
-    robots: farmNoindex
+    robots: openNoindex
       ? { index: false, follow: true }
       : { index: true, follow: true },
     openGraph: {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -3,16 +3,13 @@
 import React, { Suspense, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { trackBlogPostClick, trackBlogPlatformView } from '../lib/analytics/events';
-import { featuredArticles, type Article } from '../lib/blog/articles';
+import { trackBlogPostClick } from '../lib/analytics/events';
 import ProductionNavbar from '../components/marketing/ProductionNavbar';
 import SEOPageTracker from '../components/SEOPageTracker';
 import { isOpenPortfolioHost } from '@/lib/surface-host';
 import {
   OPEN_BLOG_FILTER_CHIPS,
-  POCKET_BLOG_FILTER_CHIPS,
   type OpenBlogFilterId,
-  type PocketBlogFilterId,
 } from '@/lib/canonical-claims';
 
 const POSTS_PER_PAGE = 20;
@@ -27,14 +24,9 @@ const OPEN_BLOG_CARD_HOVER_BORDER = 'rgba(245, 158, 11, 0.4)';
 const OPEN_BLOG_CARD_HOVER_SHADOW = '0 8px 24px rgba(245, 158, 11, 0.15)';
 const OPEN_BLOG_CARD_REST_SHADOW = '0 4px 18px rgba(245, 158, 11, 0.06)';
 
-type BlogCardKind = 'regular' | 'research' | 'how-to' | 'external';
+type BlogCardKind = 'regular' | 'research' | 'how-to';
 
-function blogCardHover(
-  el: HTMLElement,
-  surface: 'open' | 'pocket',
-  kind: BlogCardKind,
-  platform?: string,
-) {
+function blogCardHover(el: HTMLElement, surface: 'open' | 'pocket', kind: BlogCardKind) {
   el.style.transform = 'translateY(-4px)';
   if (surface === 'open') {
     el.style.boxShadow = OPEN_BLOG_CARD_HOVER_SHADOW;
@@ -49,12 +41,6 @@ function blogCardHover(
   if (kind === 'how-to') {
     el.style.boxShadow = '0 8px 24px rgba(0, 255, 65, 0.15)';
     el.style.borderColor = 'rgba(0, 255, 65, 0.4)';
-    return;
-  }
-  if (kind === 'external') {
-    el.style.boxShadow = '0 8px 24px rgba(99, 102, 241, 0.15)';
-    el.style.borderColor =
-      platform === 'dev.to' ? 'rgba(59, 73, 223, 0.4)' : 'rgba(139, 92, 246, 0.4)';
     return;
   }
   el.style.boxShadow = OPEN_BLOG_CARD_HOVER_SHADOW;
@@ -88,8 +74,7 @@ interface GeneratedPost {
 type GridItem =
   | { kind: 'regular'; post: GeneratedPost }
   | { kind: 'research'; post: GeneratedPost }
-  | { kind: 'how-to'; post: GeneratedPost }
-  | { kind: 'external'; article: Article };
+  | { kind: 'how-to'; post: GeneratedPost };
 
 function postKind(post: GeneratedPost): GridItem['kind'] {
   if (post.category === 'research') return 'research';
@@ -108,24 +93,8 @@ function buildOpenVisibleItems(filter: OpenBlogFilterId, posts: GeneratedPost[])
   });
 }
 
-function buildPocketVisibleItems(
-  filter: PocketBlogFilterId,
-  regularPosts: GeneratedPost[],
-  filteredArticles: Article[],
-): GridItem[] {
-  const items: GridItem[] = [];
-
-  if (filter === 'all' || filter === 'generated') {
-    regularPosts.forEach((post) => items.push({ kind: 'regular', post }));
-  }
-  if (filter === 'all' || filter === 'dev.to' || filter === 'coderlegion') {
-    const platform = filter === 'all' ? null : filter;
-    filteredArticles
-      .filter((a) => platform === null || a.platform === platform)
-      .forEach((article) => items.push({ kind: 'external', article }));
-  }
-
-  return items;
+function buildPocketVisibleItems(posts: GeneratedPost[]): GridItem[] {
+  return posts.map((post) => ({ kind: 'regular' as const, post }));
 }
 
 function BlogPageInner() {
@@ -133,7 +102,6 @@ function BlogPageInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [openFilter, setOpenFilter] = useState<OpenBlogFilterId>('all');
-  const [pocketFilter, setPocketFilter] = useState<PocketBlogFilterId>('all');
   const [generatedPosts, setGeneratedPosts] = useState<GeneratedPost[]>([]);
   const [blogSurface, setBlogSurface] = useState<'pocket' | 'open'>('pocket');
 
@@ -141,14 +109,13 @@ function BlogPageInner() {
     const surface = isOpenPortfolioHost(window.location.hostname) ? 'open' : 'pocket';
     setBlogSurface(surface);
     setOpenFilter('all');
-    setPocketFilter('all');
     fetch(`/api/blog/posts?surface=${surface}`)
       .then((res) => res.json())
       .then((data) => setGeneratedPosts(data || []))
       .catch(() => setGeneratedPosts([]));
   }, []);
 
-  const filter = blogSurface === 'open' ? openFilter : pocketFilter;
+  const filter = blogSurface === 'open' ? openFilter : 'all';
   const prevFilter = useRef(filter);
 
   useEffect(() => {
@@ -158,19 +125,10 @@ function BlogPageInner() {
     }
   }, [filter, pathname, router]);
 
-  const pocketRegularPosts = generatedPosts;
-
-  const pocketArticles =
-    pocketFilter === 'all'
-      ? featuredArticles
-      : pocketFilter === 'generated'
-        ? []
-        : featuredArticles.filter((article) => article.platform === pocketFilter);
-
   const visibleItems =
     blogSurface === 'open'
       ? buildOpenVisibleItems(openFilter, generatedPosts)
-      : buildPocketVisibleItems(pocketFilter, pocketRegularPosts, pocketArticles);
+      : buildPocketVisibleItems(generatedPosts);
 
   const cardBorder = blogSurface === 'open' ? OPEN_BLOG_CARD_BORDER : BLOG_CARD_BORDER;
   const cardBorderColor = blogSurface === 'open' ? OPEN_BLOG_CARD_BORDER_COLOR : BLOG_CARD_BORDER_COLOR;
@@ -231,10 +189,11 @@ function BlogPageInner() {
             }}
           >
             {blogSurface === 'open'
-              ? 'Research, sovereign engineering, and infrastructure deep-dives from the Open Portfolio substrate team.'
+              ? 'Sovereign engineering briefs on local-first architecture and stateless inference from the Open Portfolio team.'
               : 'Technical deep-dives, architecture decisions, and devlogs from the Pocket Portfolio team.'}
           </p>
 
+          {blogSurface === 'open' && (
           <div
             style={{
               display: 'flex',
@@ -244,26 +203,15 @@ function BlogPageInner() {
               marginBottom: '32px',
             }}
           >
-            {(blogSurface === 'open' ? OPEN_BLOG_FILTER_CHIPS : POCKET_BLOG_FILTER_CHIPS).map(
-              (chip) => {
-                const active = filter === chip.id;
-                const accent =
-                  blogSurface === 'open'
-                    ? 'var(--accent-warm)'
-                    : (chip as (typeof POCKET_BLOG_FILTER_CHIPS)[number]).accent;
-                const activeBg =
-                  blogSurface === 'open'
-                    ? 'rgba(245, 158, 11, 0.12)'
-                    : (chip as (typeof POCKET_BLOG_FILTER_CHIPS)[number]).activeBg;
-                const setChip =
-                  blogSurface === 'open'
-                    ? () => setOpenFilter(chip.id as OpenBlogFilterId)
-                    : () => setPocketFilter(chip.id as PocketBlogFilterId);
+            {OPEN_BLOG_FILTER_CHIPS.map((chip) => {
+                const active = openFilter === chip.id;
+                const accent = 'var(--accent-warm)';
+                const activeBg = 'rgba(245, 158, 11, 0.12)';
                 return (
                   <button
                     key={chip.id}
                     type="button"
-                    onClick={setChip}
+                    onClick={() => setOpenFilter(chip.id)}
                     style={{
                       padding: '8px 16px',
                       borderRadius: '8px',
@@ -279,9 +227,9 @@ function BlogPageInner() {
                     {chip.label}
                   </button>
                 );
-              },
-            )}
+              })}
           </div>
+          )}
         </header>
 
         {visibleItems.length > 0 && (
@@ -574,94 +522,7 @@ function BlogPageInner() {
               );
             }
 
-            const article = item.article;
-            return (
-              <a
-                key={`external-${article.url}`}
-                href={article.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackBlogPostClick(article.title, article.platform, article.url)}
-                style={{
-                  display: 'block',
-                  padding: '24px',
-                  background: 'hsl(var(--card))',
-                  border: cardBorder,
-                  borderRadius: '12px',
-                  transition: 'all 0.2s ease',
-                  textDecoration: 'none',
-                  color: 'inherit',
-                  cursor: 'pointer',
-                  boxShadow: cardRestShadow,
-                }}
-                onMouseEnter={(e) =>
-                  blogCardHover(e.currentTarget, blogSurface, 'external', article.platform)
-                }
-                onMouseLeave={(e) =>
-                  blogCardRest(e.currentTarget, blogSurface, cardBorderColor, cardRestShadow)
-                }
-              >
-                <div style={{ marginBottom: '12px' }}>
-                  <span
-                    style={{
-                      display: 'inline-block',
-                      padding: '4px 12px',
-                      fontSize: '12px',
-                      fontWeight: '600',
-                      borderRadius: '6px',
-                      background:
-                        article.platform === 'dev.to' ? 'rgba(59, 73, 223, 0.1)' : 'rgba(139, 92, 246, 0.1)',
-                      color: article.platform === 'dev.to' ? 'rgb(59, 73, 223)' : 'rgb(139, 92, 246)',
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.5px',
-                    }}
-                  >
-                    {article.platform === 'dev.to' ? 'DEV.TO' : 'CODERLEGION'}
-                  </span>
-                </div>
-                <h2 style={{ fontSize: '20px', fontWeight: '600', marginBottom: '8px', lineHeight: '1.4' }}>
-                  {article.title}
-                </h2>
-                <p style={{ fontSize: '14px', color: 'var(--text-muted)', marginBottom: '16px', lineHeight: '1.6' }}>
-                  {article.description}
-                </p>
-                <div
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--text-muted)',
-                    marginBottom: '12px',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '4px',
-                  }}
-                >
-                  <div>
-                    {new Date(article.date).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })}
-                  </div>
-                  <div>By {article.author}</div>
-                </div>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
-                  {article.tags.map((tag, i) => (
-                    <span
-                      key={i}
-                      style={{
-                        fontSize: '11px',
-                        padding: '2px 8px',
-                        background: 'var(--muted)',
-                        borderRadius: '4px',
-                        color: 'var(--text-muted)',
-                      }}
-                    >
-                      #{tag}
-                    </span>
-                  ))}
-                </div>
-              </a>
-            );
+            return null;
           })}
         </div>
 
@@ -715,115 +576,6 @@ function BlogPageInner() {
               Next
             </button>
           </nav>
-        )}
-
-        {blogSurface === 'pocket' && (
-        <div
-          style={{
-            textAlign: 'center',
-            padding: '48px 24px',
-            background: 'hsl(var(--card))',
-            borderRadius: '12px',
-            border: BLOG_CARD_BORDER,
-            boxShadow: '0 4px 18px rgba(245, 158, 11, 0.06)',
-          }}
-        >
-          <h2 style={{ fontSize: '24px', fontWeight: '600', marginBottom: '16px' }}>Want More Content?</h2>
-          <p style={{ fontSize: '16px', color: 'var(--text-muted)', marginBottom: '24px' }}>
-            Follow us on dev.to and join discussions on CoderLegion
-          </p>
-          <div
-            style={{
-              display: 'inline-flex',
-              gap: '12px',
-              flexWrap: 'wrap',
-              justifyContent: 'center',
-            }}
-          >
-            <a
-              href="https://dev.to/pocketportfolioapp"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => trackBlogPlatformView('dev.to', 'view_all')}
-              style={{
-                padding: '12px 24px',
-                fontSize: '15px',
-                fontWeight: '600',
-                borderRadius: '8px',
-                background: 'linear-gradient(135deg, rgba(59, 73, 223, 0.9) 0%, rgba(59, 73, 223, 1) 100%)',
-                color: 'white',
-                textDecoration: 'none',
-                display: 'inline-block',
-                transition: 'all 0.2s ease',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-2px)';
-                e.currentTarget.style.boxShadow = '0 4px 12px rgba(59, 73, 223, 0.3)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.boxShadow = 'none';
-              }}
-            >
-              View All Dev.to Articles →
-            </a>
-            <Link
-              href="/blog?page=1"
-              onClick={() => {
-                setPocketFilter('generated');
-                trackBlogPlatformView('pocket-portfolio', 'view_all');
-              }}
-              style={{
-                padding: '12px 24px',
-                fontSize: '15px',
-                fontWeight: '600',
-                borderRadius: '8px',
-                background: 'linear-gradient(135deg, rgba(245, 158, 11, 0.9) 0%, rgba(245, 158, 11, 1) 100%)',
-                color: 'white',
-                textDecoration: 'none',
-                display: 'inline-block',
-                transition: 'all 0.2s ease',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-2px)';
-                e.currentTarget.style.boxShadow = '0 4px 12px rgba(245, 158, 11, 0.3)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.boxShadow = 'none';
-              }}
-            >
-              View Pocket Portfolio Posts →
-            </Link>
-            <a
-              href="https://coderlegion.com/5738/welcome-to-coderlegion-22s"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => trackBlogPlatformView('coderlegion', 'join_discussion')}
-              style={{
-                padding: '12px 24px',
-                fontSize: '15px',
-                fontWeight: '600',
-                borderRadius: '8px',
-                background: 'linear-gradient(135deg, rgba(139, 92, 246, 0.9) 0%, rgba(139, 92, 246, 1) 100%)',
-                color: 'white',
-                textDecoration: 'none',
-                display: 'inline-block',
-                transition: 'all 0.2s ease',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-2px)';
-                e.currentTarget.style.boxShadow = '0 4px 12px rgba(139, 92, 246, 0.3)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.boxShadow = 'none';
-              }}
-            >
-              Join CoderLegion Discussion →
-            </a>
-          </div>
-        </div>
         )}
       </div>
     </>

--- a/app/open/__not-a-b2b-route__/not-found.tsx
+++ b/app/open/__not-a-b2b-route__/not-found.tsx
@@ -1,0 +1,2 @@
+/** Segment not-found so middleware rewrite → notFound() keeps O. chrome (not root Pocket 404). */
+export { default } from '../not-found';

--- a/app/open/__not-a-b2b-route__/page.tsx
+++ b/app/open/__not-a-b2b-route__/page.tsx
@@ -1,6 +1,10 @@
 import { notFound } from 'next/navigation';
 
-/** Middleware rewrite target for non-B2B paths on the O. host (triggers app/open/not-found.tsx). */
+/**
+ * Middleware rewrite target for non-B2B paths on the O. host.
+ * Calls notFound() → this segment's not-found.tsx (Open chrome + 404 status).
+ * Pocket-owned paths (e.g. /book/*) should redirect via isPocketOnlyMarketingPath instead.
+ */
 export default function OpenB2bUnknownRoute() {
   notFound();
 }

--- a/app/open/blog/page.tsx
+++ b/app/open/blog/page.tsx
@@ -3,9 +3,9 @@ import BlogPage from '../../blog/page';
 import { OPEN_URLS, SURFACE_ORG } from '../../../lib/canonical-claims';
 
 export const metadata: Metadata = {
-  title: 'Engineering & Research Blog',
+  title: 'Institutional Engineering Blog',
   description:
-    'Technical deep-dives on sovereign finance, local-first architecture, and stateless inference from Open Portfolio.',
+    'Sovereign engineering briefs on local-first architecture and stateless inference from Open Portfolio.',
   alternates: { canonical: `${OPEN_URLS.home}/blog` },
   openGraph: {
     title: 'Open Portfolio Blog',

--- a/content/posts/bypassing-approved-supplier-list-compliance.mdx
+++ b/content/posts/bypassing-approved-supplier-list-compliance.mdx
@@ -73,11 +73,11 @@ No. Model providers and hosting still require review. The win is **narrower scop
 Many firms run **sandbox exceptions** when data categories are bounded and retention is forgetful on the inference path. Frame the pilot as edge-only parse with network captures—not production rollout.
 
 **What if our network blocks all external LLM calls?**  
-BYOC and VPC-side deployment are the enterprise extension of the same contract. See the [90-day sandbox reference pattern](/blog/tier-1-wealth-byoc-sandbox-pattern).
+BYOC and VPC-side deployment are the enterprise extension of the same contract. See the [90-day sandbox reference pattern](https://www.pocketportfolio.app/blog/tier-1-wealth-byoc-sandbox-pattern).
 
 **Where is the importer source?**  
 `packages/importer` on npm as `@pocket-portfolio/importer` — inspectable MIT boundary.
 
 ---
 
-**Next steps:** [Architecture](/architecture) · [Tier-1 design partner](/tier1designpartner) · Sovereign Engineering [Serial 01](/blog/sovereign-engineering-serial-01-compliance-trap) · [Serial 03](/blog/sovereign-engineering-serial-03-edge-compiler)
+**Next steps:** [Architecture](/architecture) · [Tier-1 design partner](/tier1designpartner) · [Data Chasm brief](/blog/data-chasm-wealth-management-llms) · [Enterprise design partnership](/learn/enterprise-design-partnership)

--- a/content/posts/data-chasm-wealth-management-llms.mdx
+++ b/content/posts/data-chasm-wealth-management-llms.mdx
@@ -87,4 +87,4 @@ Attachments are an explicit second boundary with server-side length caps. Defaul
 
 ---
 
-**Next steps:** [Architecture](/architecture) · [Tier-1 design partner](/tier1designpartner) · Sovereign Engineering [Serial 01](/blog/sovereign-engineering-serial-01-compliance-trap) · [Serial 03](/blog/sovereign-engineering-serial-03-edge-compiler)
+**Next steps:** [Architecture](/architecture) · [Tier-1 design partner](/tier1designpartner) · [Forgetful sessions brief](/blog/structuring-forgetful-sessions-financial-rag) · [Sovereign AI Architecture](/learn/sovereign-ai-architecture)

--- a/content/posts/sovereign-engineering-serial-01-compliance-trap.mdx
+++ b/content/posts/sovereign-engineering-serial-01-compliance-trap.mdx
@@ -1,8 +1,11 @@
 ---
-title: 'The End of Data Export — Why the Cloud is a Compliance Trap'
+title: The End of Data Export — Why the Cloud is a Compliance Trap
 date: '2026-04-10'
 description: >-
-  Sovereignty is Pocket Portfolio’s architecture philosophy—user-anchored truth, bounded cloud inference, stateless /api/ai/chat (no portfolio payload persistence; quota + toolUsage metadata only). Versus the typical central-DB + full-prompt SaaS path. Part 1 of Sovereign Engineering.
+  Sovereignty is Pocket Portfolio’s architecture philosophy—user-anchored truth,
+  bounded cloud inference, stateless /api/ai/chat (no portfolio payload
+  persistence; quota + toolUsage metadata only). Versus the typical central-DB +
+  full-prompt SaaS path. Part 1 of Sovereign Engineering.
 tags:
   - local-first
   - ai
@@ -13,6 +16,8 @@ image: /book-assets/sovereign-engineering-covers/se-01.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 1**
@@ -60,4 +65,4 @@ await db.collection('toolUsage').add({
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-02-split-brain.mdx
+++ b/content/posts/sovereign-engineering-serial-02-split-brain.mdx
@@ -1,8 +1,9 @@
 ---
-title: 'Split-Brain — Analyst-Grade Reasoning Without Raw Transactions on the Server'
+title: Split-Brain — Analyst-Grade Reasoning Without Raw Transactions on the Server
 date: '2026-04-17'
 description: >-
-  buildPortfolioContext: thousands of trades to a ~1–2KB semantic summary; AskAIModal sends only context + message. Part 2 of Sovereign Engineering.
+  buildPortfolioContext: thousands of trades to a ~1–2KB semantic summary;
+  AskAIModal sends only context + message. Part 2 of Sovereign Engineering.
 tags:
   - rag
   - architecture
@@ -13,6 +14,8 @@ image: /book-assets/sovereign-engineering-covers/se-02.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 2**
@@ -80,4 +83,4 @@ export function buildPortfolioContext(
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-03-edge-compiler.mdx
+++ b/content/posts/sovereign-engineering-serial-03-edge-compiler.mdx
@@ -1,8 +1,10 @@
 ---
-title: 'Sanitization by Construction — The Edge Compiler'
+title: Sanitization by Construction — The Edge Compiler
 date: '2026-04-24'
 description: >-
-  No regex PII roulette: buildPortfolioContext structurally excludes row dumps. CSV import is a separate pipeline; the AI boundary is totals + top-N only. Part 3 of Sovereign Engineering.
+  No regex PII roulette: buildPortfolioContext structurally excludes row dumps.
+  CSV import is a separate pipeline; the AI boundary is totals + top-N only.
+  Part 3 of Sovereign Engineering.
 tags:
   - privacy
   - typescript
@@ -12,6 +14,8 @@ image: /book-assets/sovereign-engineering-covers/se-03.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 3**
@@ -24,4 +28,4 @@ Default Ask AI: **Network tab** shows a short `context` string, not your full ex
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-04-viral-scale.mdx
+++ b/content/posts/sovereign-engineering-serial-04-viral-scale.mdx
@@ -2,7 +2,9 @@
 title: '4,669 Active Users in 28 Days — Referral Spike on Stateless Infra'
 date: '2026-05-01'
 description: >-
-  28-day GA4 window (Mar 6–Apr 2, 2026): 4,669 active users, 4,500 new. Apex→www middleware, stateless chat, Firestore referral paths. Part 4 of Sovereign Engineering.
+  28-day GA4 window (Mar 6–Apr 2, 2026): 4,669 active users, 4,500 new. Apex→www
+  middleware, stateless chat, Firestore referral paths. Part 4 of Sovereign
+  Engineering.
 tags:
   - growth
   - nextjs
@@ -13,6 +15,8 @@ image: /book-assets/sovereign-engineering-covers/se-04.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 4**
@@ -34,4 +38,4 @@ category: sovereign-engineering
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-05-browser-vault.mdx
+++ b/content/posts/sovereign-engineering-serial-05-browser-vault.mdx
@@ -1,8 +1,10 @@
 ---
-title: 'Browser Storage as the Financial Vault'
+title: Browser Storage as the Financial Vault
 date: '2026-05-08'
 description: >-
-  Three persistence lanes: localStorage (pocket-portfolio-local-trades), Firebase TradeService for auth users, Zustand partialize for prefs only, plus IndexedDB cache clear on logout. Part 5 of Sovereign Engineering.
+  Three persistence lanes: localStorage (pocket-portfolio-local-trades),
+  Firebase TradeService for auth users, Zustand partialize for prefs only, plus
+  IndexedDB cache clear on logout. Part 5 of Sovereign Engineering.
 tags:
   - local-first
   - storage
@@ -13,6 +15,8 @@ image: /book-assets/sovereign-engineering-covers/se-05.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 5**
@@ -39,4 +43,4 @@ Clears **Firestore client cache** (IndexedDB), not “the vault” for guests.
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-06-prompt-grounding.mdx
+++ b/content/posts/sovereign-engineering-serial-06-prompt-grounding.mdx
@@ -1,8 +1,9 @@
 ---
-title: 'Prompt Grounding — Layers in app/api/ai/chat/route.ts'
+title: Prompt Grounding — Layers in app/api/ai/chat/route.ts
 date: '2026-05-15'
 description: >-
-  SYSTEM_PROMPT + contextBlock + quoteBlock + attachedBlock; extractSymbolHints for live quotes; Gemini/OpenAI routing. Part 6 of Sovereign Engineering.
+  SYSTEM_PROMPT + contextBlock + quoteBlock + attachedBlock; extractSymbolHints
+  for live quotes; Gemini/OpenAI routing. Part 6 of Sovereign Engineering.
 tags:
   - prompting
   - ai
@@ -12,6 +13,8 @@ image: /book-assets/sovereign-engineering-covers/se-06.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 6**
@@ -32,4 +35,4 @@ Quotes: `extractSymbolHints(message)` → internal `/api/quote`. Attachments: **
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-07-viral-loop.mdx
+++ b/content/posts/sovereign-engineering-serial-07-viral-loop.mdx
@@ -1,8 +1,10 @@
 ---
-title: 'Referral Loop — referralEvents + referral/complete'
+title: Referral Loop — referralEvents + referral/complete
 date: '2026-05-22'
 description: >-
-  POST /api/referral-event (click|conversion, bounded metadata); POST /api/referral/complete (auth, REF-* codes, idempotent claims). Middleware apex→www. Part 7.
+  POST /api/referral-event (click|conversion, bounded metadata); POST
+  /api/referral/complete (auth, REF-* codes, idempotent claims). Middleware
+  apex→www. Part 7.
 tags:
   - growth
   - firebase
@@ -12,6 +14,8 @@ image: /book-assets/sovereign-engineering-covers/se-07.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 7**
@@ -30,4 +34,4 @@ await db.collection('referralEvents').add({
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-08-amber-email.mdx
+++ b/content/posts/sovereign-engineering-serial-08-amber-email.mdx
@@ -1,8 +1,10 @@
 ---
-title: 'Amber Terminal Email — Design Tokens in TypeScript'
+title: Amber Terminal Email — Design Tokens in TypeScript
 date: '2026-05-29'
 description: >-
-  viral-moment-announce-email.ts: BG #0a0a0a, AMBER #FFBF00, inline HTML for email clients; buildViralMomentAnnounceHtml for Resend + viral-moment-blast cron. Part 8.
+  viral-moment-announce-email.ts: BG #0a0a0a, AMBER #FFBF00, inline HTML for
+  email clients; buildViralMomentAnnounceHtml for Resend + viral-moment-blast
+  cron. Part 8.
 tags:
   - email
   - branding
@@ -12,6 +14,8 @@ image: /book-assets/sovereign-engineering-covers/se-08.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 8**
@@ -27,4 +31,4 @@ No external stylesheet — **table + inline `style=`** only. Micro-label: `LOCAL
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-09-admin-analytics.mdx
+++ b/content/posts/sovereign-engineering-serial-09-admin-analytics.mdx
@@ -1,8 +1,10 @@
 ---
-title: 'Admin Analytics — Aggregates Without Portfolio Rows'
+title: Admin Analytics — Aggregates Without Portfolio Rows
 date: '2026-06-05'
 description: >-
-  GET /api/admin/analytics: Stripe, referrals, viral blast, npm, toolUsage metadata. UI app/admin/analytics/page.tsx. GA4 for acquisition; admin for ops. Part 9.
+  GET /api/admin/analytics: Stripe, referrals, viral blast, npm, toolUsage
+  metadata. UI app/admin/analytics/page.tsx. GA4 for acquisition; admin for ops.
+  Part 9.
 tags:
   - analytics
   - admin
@@ -12,6 +14,8 @@ image: /book-assets/sovereign-engineering-covers/se-09.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 9**
@@ -22,4 +26,4 @@ category: sovereign-engineering
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-10-roadmap-parser.mdx
+++ b/content/posts/sovereign-engineering-serial-10-roadmap-parser.mdx
@@ -1,8 +1,11 @@
 ---
-title: 'Beyond the CSV — Universal Statement Parser (roadmap)'
+title: Beyond the CSV — Universal Statement Parser (roadmap)
 date: '2026-06-12'
 description: >-
-  CSV and broker adapters ship today; PDF statements are the harder next surface. Extract → map → deterministic parse → human review—same sovereign discipline as CSV, not yet a live end-to-end product path. Part 10 of Sovereign Engineering.
+  CSV and broker adapters ship today; PDF statements are the harder next
+  surface. Extract → map → deterministic parse → human review—same sovereign
+  discipline as CSV, not yet a live end-to-end product path. Part 10 of
+  Sovereign Engineering.
 tags:
   - import
   - roadmap
@@ -12,8 +15,8 @@ image: /book-assets/sovereign-engineering-covers/se-10.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
-# Roadmap-only; omit from homepage “Building in Public” — still listed on /blog
 excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 10**
@@ -22,4 +25,4 @@ Today the product centers on **CSV** and **broker adapters**, with parsing weigh
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-11-vision-b2b.mdx
+++ b/content/posts/sovereign-engineering-serial-11-vision-b2b.mdx
@@ -1,8 +1,10 @@
 ---
-title: 'Stateless B2B Gateway — Sovereign AI for Institutions (vision)'
+title: Stateless B2B Gateway — Sovereign AI for Institutions (vision)
 date: '2026-06-19'
 description: >-
-  Bank-grade means data-handling posture: local-first truth, bounded egress, stateless inference, telemetry split from prompts—not a stand-in for SOC 2 on paper. Vision for VPC-side gateway. Part 11 of Sovereign Engineering.
+  Bank-grade means data-handling posture: local-first truth, bounded egress,
+  stateless inference, telemetry split from prompts—not a stand-in for SOC 2 on
+  paper. Vision for VPC-side gateway. Part 11 of Sovereign Engineering.
 tags:
   - b2b
   - vision
@@ -12,6 +14,8 @@ image: /book-assets/sovereign-engineering-covers/se-11.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 11**
@@ -20,4 +24,4 @@ category: sovereign-engineering
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-engineering-serial-12-route-to-rise.mdx
+++ b/content/posts/sovereign-engineering-serial-12-route-to-rise.mdx
@@ -2,7 +2,9 @@
 title: 'The Global Frontier — UK Engineering, Global Reach (Route to Rise)'
 date: '2026-06-26'
 description: >-
-  Greater Manchester / Salford base; MIDAS & Invest Manchester ecosystem; Sovereign stack built for global distribution. Serial receipts + GA4 geography caveat. Parts 10–11 roadmap/vision. Part 12 finale.
+  Greater Manchester / Salford base; MIDAS & Invest Manchester ecosystem;
+  Sovereign stack built for global distribution. Serial receipts + GA4 geography
+  caveat. Parts 10–11 roadmap/vision. Part 12 finale.
 tags:
   - founders
   - ai
@@ -12,6 +14,8 @@ image: /book-assets/sovereign-engineering-covers/se-12.png
 pillar: technical
 series: Sovereign Engineering
 category: sovereign-engineering
+excludeFromLanding: true
+noindex: true
 ---
 
 **Sovereign Engineering · Part 12 (finale)**
@@ -22,4 +26,4 @@ category: sovereign-engineering
 
 ---
 
-**Read the [Sovereign Intelligence](/book/sovereign-intelligence) book or [try Pocket Portfolio](/).**
+**Read the [Sovereign Intelligence](https://www.pocketportfolio.app/book/sovereign-intelligence) book or [try Pocket Portfolio](https://www.pocketportfolio.app/).**

--- a/content/posts/sovereign-serial-1-fragmentation-problem.mdx
+++ b/content/posts/sovereign-serial-1-fragmentation-problem.mdx
@@ -42,6 +42,6 @@ Schema inference produces a mapping: `date → "Deal Date"`, `ticker → "Epic"`
 
 ---
 
-*This is part 1 of the **Sovereign Serial**—a 12-part technical series adapted from the book [Universal LLM Import: Building Local-First, Sovereign CSV Ingestion](/book/universal-llm-import).*
+*This is part 1 of the **Sovereign Serial**—a 12-part technical series adapted from the book [Universal LLM Import: Building Local-First, Sovereign CSV Ingestion](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-10-security-threat-modeling.mdx
+++ b/content/posts/sovereign-serial-10-security-threat-modeling.mdx
@@ -42,6 +42,6 @@ No server-side processing of full trade history. User initiates export and uploa
 
 ---
 
-*Part 10 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 10 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-11-use-cases-client-etl.mdx
+++ b/content/posts/sovereign-serial-11-use-cases-client-etl.mdx
@@ -35,6 +35,6 @@ The pattern "headers + sample → mapping → deterministic parse" is **generic.
 
 ---
 
-*Part 11 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 11 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-12-future-client-side-ai.mdx
+++ b/content/posts/sovereign-serial-12-future-client-side-ai.mdx
@@ -42,6 +42,6 @@ Regulation has pushed some banks and brokers to expose APIs, but coverage is une
 
 ---
 
-*Part 12 of the **Sovereign Serial**—the final installment. Adapted from [Universal LLM Import: Building Local-First, Sovereign CSV Ingestion](/book/universal-llm-import).*
+*Part 12 of the **Sovereign Serial**—the final installment. Adapted from [Universal LLM Import: Building Local-First, Sovereign CSV Ingestion](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-2-csv-over-apis.mdx
+++ b/content/posts/sovereign-serial-2-csv-over-apis.mdx
@@ -35,6 +35,6 @@ APIs give real-time data and automatic sync but at the cost of fragility and ven
 
 ---
 
-*Part 2 of the **Sovereign Serial**. Adapted from [Universal LLM Import](/book/universal-llm-import).*
+*Part 2 of the **Sovereign Serial**. Adapted from [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-3-local-first-browser.mdx
+++ b/content/posts/sovereign-serial-3-local-first-browser.mdx
@@ -39,6 +39,6 @@ So "data never leaving the client" holds for the full CSV; the only exception is
 
 ---
 
-*Part 3 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 3 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-4-bifurcated-pipeline.mdx
+++ b/content/posts/sovereign-serial-4-bifurcated-pipeline.mdx
@@ -38,6 +38,6 @@ If confidence ≥ 0.9 and all required fields are mapped, the pipeline runs the 
 
 ---
 
-*Part 4 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 4 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-5-three-row-snapshot.mdx
+++ b/content/posts/sovereign-serial-5-three-row-snapshot.mdx
@@ -36,6 +36,6 @@ The API contract is stable: headers and sample rows in, mapping out. You can imp
 
 ---
 
-*Part 5 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 5 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-6-data-normalization.mdx
+++ b/content/posts/sovereign-serial-6-data-normalization.mdx
@@ -38,6 +38,6 @@ Bad date, non-numeric quantity, or skip conditions (e.g. dividend rows) produce 
 
 ---
 
-*Part 6 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 6 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-7-drive-dumb-storage.mdx
+++ b/content/posts/sovereign-serial-7-drive-dumb-storage.mdx
@@ -35,6 +35,6 @@ Conflict handling (e.g. optimistic locking with revision IDs) runs in the client
 
 ---
 
-*Part 7 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 7 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-8-interface-uncertainty.mdx
+++ b/content/posts/sovereign-serial-8-interface-uncertainty.mdx
@@ -35,6 +35,6 @@ Metrics that matter: funnel (drop → complete import), path split (dedicated vs
 
 ---
 
-*Part 8 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 8 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/sovereign-serial-9-universal-vs-plaid.mdx
+++ b/content/posts/sovereign-serial-9-universal-vs-plaid.mdx
@@ -38,6 +38,6 @@ Many products offer **both**: API for users who want automatic sync, and CSV for
 
 ---
 
-*Part 9 of the **Sovereign Serial**. From [Universal LLM Import](/book/universal-llm-import).*
+*Part 9 of the **Sovereign Serial**. From [Universal LLM Import](https://www.pocketportfolio.app/book/universal-llm-import).*
 
-**Read the full [Bestseller Edition](/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**
+**Read the full [Bestseller Edition](https://www.pocketportfolio.app/book/universal-llm-import) or [Try the app](https://www.pocketportfolio.app).**

--- a/content/posts/structuring-forgetful-sessions-financial-rag.mdx
+++ b/content/posts/structuring-forgetful-sessions-financial-rag.mdx
@@ -88,8 +88,8 @@ Portfolio context is not persisted server-side for inference as designed. Teleme
 Fine-tuning on itemized ledgers is the highest-risk pattern for wealth. Bounded aggregates + stateless inference keep training data out of scope for the default product path.
 
 **Where is the full technical blueprint?**  
-[Sovereign Intelligence book](/book/sovereign-intelligence) · Serial [03 — Edge Compiler](/blog/sovereign-engineering-serial-03-edge-compiler).
+[Sovereign Intelligence book](https://www.pocketportfolio.app/book/sovereign-intelligence) · [Sovereign AI Architecture](/learn/sovereign-ai-architecture)
 
 ---
 
-**Next steps:** [Architecture](/architecture) · [Tier-1 design partner](/tier1designpartner) · Sovereign Engineering [Serial 01](/blog/sovereign-engineering-serial-01-compliance-trap) · [Serial 03](/blog/sovereign-engineering-serial-03-edge-compiler)
+**Next steps:** [Architecture](/architecture) · [Tier-1 design partner](/tier1designpartner) · [Data Chasm brief](/blog/data-chasm-wealth-management-llms) · [Stateless edge ingestion](/learn/stateless-edge-ingestion)

--- a/lib/blog-sitemap-entries.ts
+++ b/lib/blog-sitemap-entries.ts
@@ -7,15 +7,16 @@ import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
 import {
-  isOpenBlogCategory,
+  isOpenBlogListingCategory,
   isPocketBlogCategory,
-  shouldNoindexOpenBlogFarm,
 } from './canonical-claims';
 
 export interface BlogPostSitemapEntry {
   slug: string;
   category: string | undefined;
   lastModified: Date;
+  excludeFromLanding?: boolean;
+  noindex?: boolean;
 }
 
 export function loadBlogPostSitemapEntries(): BlogPostSitemapEntry[] {
@@ -36,6 +37,8 @@ export function loadBlogPostSitemapEntries(): BlogPostSitemapEntry[] {
         slug,
         category: typeof data.category === 'string' ? data.category : undefined,
         lastModified: data.date ? new Date(data.date) : now,
+        excludeFromLanding: data.excludeFromLanding === true,
+        noindex: data.noindex === true,
       });
     } catch (err) {
       console.error(`[blog-sitemap-entries] Error processing ${file}:`, err);
@@ -51,11 +54,11 @@ export function partitionBlogPostsForSitemap(entries: BlogPostSitemapEntry[]): {
 } {
   return {
     pocket: entries.filter((e) => isPocketBlogCategory(e.category)),
-    // Wave 1: keep how-to/research crawlable via links but out of sitemap index slots
     open: entries.filter(
       (e) =>
-        isOpenBlogCategory(e.category) &&
-        !shouldNoindexOpenBlogFarm(e.category, e.slug),
+        isOpenBlogListingCategory(e.category, e.slug) &&
+        !e.excludeFromLanding &&
+        !e.noindex,
     ),
   };
 }

--- a/lib/canonical-claims.ts
+++ b/lib/canonical-claims.ts
@@ -844,8 +844,8 @@ export const SURFACE_CROSS_LINKS = {
 } as const;
 
 /**
- * Blog categories shown on Open Portfolio (B2B). Cron still writes all posts to
- * content/posts — filtering is presentation-only so autonomous generation is unchanged.
+ * Blog categories owned by Open Portfolio (B2B host). Includes farm categories for
+ * dual-surface routing of existing MDX; listing/sitemap use {@link isOpenBlogListingCategory}.
  */
 export const OPEN_BLOG_CATEGORIES = [
   'research',
@@ -861,7 +861,8 @@ export function isOpenBlogCategory(category: string | undefined): boolean {
 
 /**
  * Wave 1 content doctrine: generic how-to / research farm posts stay crawlable for links
- * but must not compete for index slots. Sovereign engineering stays indexable.
+ * but must not compete for index slots. Sovereign engineering stays indexable unless
+ * {@link isOpenInternalEngineeringDiary}.
  */
 export function shouldNoindexOpenBlogFarm(
   category: string | undefined,
@@ -874,51 +875,57 @@ export function shouldNoindexOpenBlogFarm(
   return s.startsWith('research-') || s.startsWith('how-to-');
 }
 
+/**
+ * Internal "Sovereign Engineering · Part N" build diaries (file paths, admin routes,
+ * roadmap stubs). Not buyer-facing — hide from Open hub/sitemap and noindex.
+ */
+export function isOpenInternalEngineeringDiary(slug?: string): boolean {
+  return (slug ?? '').toLowerCase().startsWith('sovereign-engineering-serial-');
+}
+
+/** Open post robots: farm + internal engineering diaries. */
+export function shouldNoindexOpenBlogPost(
+  category: string | undefined,
+  slug?: string,
+): boolean {
+  return (
+    shouldNoindexOpenBlogFarm(category, slug) || isOpenInternalEngineeringDiary(slug)
+  );
+}
+
+/** Open /blog hub + Open sitemap — institutional buyer briefs only. */
+export function isOpenBlogListingCategory(
+  category: string | undefined,
+  slug?: string,
+): boolean {
+  return (
+    isOpenBlogCategory(category) &&
+    !shouldNoindexOpenBlogFarm(category, slug) &&
+    !isOpenInternalEngineeringDiary(slug)
+  );
+}
+
 /** First-party MDX on Pocket (B2C) — excludes Open-only categories. */
 export function isPocketBlogCategory(category: string | undefined): boolean {
   const c = category ?? 'deep-dive';
   return !isOpenBlogCategory(c);
 }
 
-/** Blog hub filter chips — www.openportfolio.co.uk/blog (B2B substrate content). */
+/** Blog hub filter chips — www.openportfolio.co.uk/blog (allowed institutional only). */
 export const OPEN_BLOG_FILTER_CHIPS = [
-  { id: 'all' as const, label: 'All technical posts' },
+  { id: 'all' as const, label: 'All institutional posts' },
   { id: 'sovereign-engineering' as const, label: 'Sovereign Engineering' },
-  { id: 'how-to-in-tech' as const, label: 'How to in Tech' },
-  { id: 'research' as const, label: 'Research' },
 ] as const;
 
 export type OpenBlogFilterId = (typeof OPEN_BLOG_FILTER_CHIPS)[number]['id'];
 
 /**
  * Blog hub filter chips — www.pocketportfolio.app/blog (B2C building in public).
+ * First-party deep-dives only — no Dev.to / CoderLegion syndication on this hub.
  * No Sovereign Engineering / research / how-to pillars here — those live on Open.
  */
 export const POCKET_BLOG_FILTER_CHIPS = [
-  {
-    id: 'all' as const,
-    label: 'All Posts',
-    accent: 'var(--accent-warm)',
-    activeBg: 'rgba(245, 158, 11, 0.12)',
-  },
-  {
-    id: 'dev.to' as const,
-    label: 'Dev.to',
-    accent: 'rgb(59, 73, 223)',
-    activeBg: 'rgba(59, 73, 223, 0.12)',
-  },
-  {
-    id: 'coderlegion' as const,
-    label: 'CoderLegion',
-    accent: 'rgb(139, 92, 246)',
-    activeBg: 'rgba(139, 92, 246, 0.12)',
-  },
-  {
-    id: 'generated' as const,
-    label: 'Pocket Portfolio Posts',
-    accent: 'var(--accent-warm)',
-    activeBg: 'rgba(245, 158, 11, 0.12)',
-  },
+  { id: 'all' as const, label: 'All Posts' },
 ] as const;
 
 export type PocketBlogFilterId = (typeof POCKET_BLOG_FILTER_CHIPS)[number]['id'];

--- a/lib/surface-host.ts
+++ b/lib/surface-host.ts
@@ -71,6 +71,8 @@ export const POCKET_ONLY_PATH_PREFIXES = [
   '/api-keys',
   '/privacy',
   '/terms',
+  /** Technical books live on Pocket (canonical pocketportfolio.app/book/…). */
+  '/book/',
 ] as const;
 
 export function isPocketOnlyMarketingPath(pathname: string): boolean {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,8 +13,8 @@ Pocket Portfolio is the Sovereign Ingestion & Inference Layer for wealth-tech: a
 ## Institutional Architecture Briefs (Open Portfolio)
 - [Sovereign AI Architecture & Data Perimeters](https://www.openportfolio.co.uk/learn/sovereign-ai-architecture)
 - [DORA & EU AI Act for Wealth Management](https://www.openportfolio.co.uk/learn/dora-eu-ai-act-wealth)
-- [Stateless Edge Ingestion](https://www.openportfolio.co.uk/learn/stateless-edge-ingestion)
-- [Enterprise Design Partnership](https://www.openportfolio.co.uk/learn/enterprise-design-partnership)
+- [Stateless Edge Ingestion vs Centralized Warehousing](https://www.openportfolio.co.uk/learn/stateless-edge-ingestion)
+- [Enterprise Design Partnership Program](https://www.openportfolio.co.uk/learn/enterprise-design-partnership)
 
 ## SDK
 - Primary package: @pocket-portfolio/importer v1.1.0 (MIT)

--- a/public/open/llms.txt
+++ b/public/open/llms.txt
@@ -13,8 +13,8 @@ Open Portfolio is the B2B developer and infrastructure gateway for the sovereign
 ## Institutional Architecture Briefs
 - [Sovereign AI Architecture & Data Perimeters](https://www.openportfolio.co.uk/learn/sovereign-ai-architecture)
 - [DORA & EU AI Act for Wealth Management](https://www.openportfolio.co.uk/learn/dora-eu-ai-act-wealth)
-- [Stateless Edge Ingestion](https://www.openportfolio.co.uk/learn/stateless-edge-ingestion)
-- [Enterprise Design Partnership](https://www.openportfolio.co.uk/learn/enterprise-design-partnership)
+- [Stateless Edge Ingestion vs Centralized Warehousing](https://www.openportfolio.co.uk/learn/stateless-edge-ingestion)
+- [Enterprise Design Partnership Program](https://www.openportfolio.co.uk/learn/enterprise-design-partnership)
 
 ## Data Perimeter & Security
 Open Portfolio enforces a Split-Brain execution model. Frontier models operate as invited guests — never receiving raw data warehouses or PII.

--- a/tests/unit/blog-sitemap-entries.spec.ts
+++ b/tests/unit/blog-sitemap-entries.spec.ts
@@ -17,6 +17,15 @@ describe('partitionBlogPostsForSitemap', () => {
       base({ slug: 'a', category: 'research' }),
       base({ slug: 'b', category: 'how-to-in-tech' }),
       base({ slug: 'c', category: 'sovereign-engineering' }),
+      base({
+        slug: 'sovereign-engineering-serial-09-admin-analytics',
+        category: 'sovereign-engineering',
+      }),
+      base({
+        slug: 'data-chasm-wealth-management-llms',
+        category: 'sovereign-engineering',
+        excludeFromLanding: true,
+      }),
     ]);
     expect(pocket).toHaveLength(0);
     expect(open.map((e) => e.slug)).toEqual(['c']);

--- a/tests/unit/blog-surfaces.spec.ts
+++ b/tests/unit/blog-surfaces.spec.ts
@@ -4,16 +4,57 @@ import {
   OPEN_BLOG_FILTER_CHIPS,
   POCKET_BLOG_FILTER_CHIPS,
   isOpenBlogCategory,
+  isOpenBlogListingCategory,
+  isOpenInternalEngineeringDiary,
   isPocketBlogCategory,
+  shouldNoindexOpenBlogFarm,
+  shouldNoindexOpenBlogPost,
 } from '../../lib/canonical-claims';
 
 describe('blog surface pillars', () => {
-  test('open categories are substrate-only', () => {
+  test('open categories still include farm for dual-surface routing', () => {
     expect(OPEN_BLOG_CATEGORIES).toEqual([
       'research',
       'sovereign-engineering',
       'how-to-in-tech',
     ]);
+  });
+
+  test('open listing excludes farm how-to/research', () => {
+    expect(
+      isOpenBlogListingCategory(
+        'sovereign-engineering',
+        'data-chasm-wealth-management-llms',
+      ),
+    ).toBe(true);
+    expect(isOpenBlogListingCategory('research')).toBe(false);
+    expect(isOpenBlogListingCategory('how-to-in-tech')).toBe(false);
+    expect(shouldNoindexOpenBlogFarm('research')).toBe(true);
+    expect(shouldNoindexOpenBlogFarm('how-to-in-tech')).toBe(true);
+  });
+
+  test('open listing excludes internal sovereign-engineering serial diaries', () => {
+    expect(
+      isOpenInternalEngineeringDiary('sovereign-engineering-serial-09-admin-analytics'),
+    ).toBe(true);
+    expect(
+      isOpenBlogListingCategory(
+        'sovereign-engineering',
+        'sovereign-engineering-serial-09-admin-analytics',
+      ),
+    ).toBe(false);
+    expect(
+      shouldNoindexOpenBlogPost(
+        'sovereign-engineering',
+        'sovereign-engineering-serial-08-amber-email',
+      ),
+    ).toBe(true);
+    expect(
+      shouldNoindexOpenBlogPost(
+        'sovereign-engineering',
+        'data-chasm-wealth-management-llms',
+      ),
+    ).toBe(false);
   });
 
   test('open and pocket category helpers are mutually exclusive', () => {
@@ -25,24 +66,22 @@ describe('blog surface pillars', () => {
     expect(isOpenBlogCategory('deep-dive')).toBe(false);
   });
 
-  test('pocket filter chips exclude open-only pillars', () => {
+  test('pocket filter chips are first-party only', () => {
     const pocketIds = POCKET_BLOG_FILTER_CHIPS.map((c) => c.id);
-    expect(pocketIds).toEqual(['all', 'dev.to', 'coderlegion', 'generated']);
+    expect(pocketIds).toEqual(['all']);
+    expect(pocketIds).not.toContain('dev.to');
+    expect(pocketIds).not.toContain('coderlegion');
+    expect(pocketIds).not.toContain('generated');
     expect(pocketIds).not.toContain('sovereign-engineering');
     expect(pocketIds).not.toContain('research');
     expect(pocketIds).not.toContain('how-to-in-tech');
   });
 
-  test('open filter chips exclude pocket community pillars', () => {
+  test('open filter chips are institutional only', () => {
     const openIds = OPEN_BLOG_FILTER_CHIPS.map((c) => c.id);
-    expect(openIds).toEqual([
-      'all',
-      'sovereign-engineering',
-      'how-to-in-tech',
-      'research',
-    ]);
+    expect(openIds).toEqual(['all', 'sovereign-engineering']);
+    expect(openIds).not.toContain('how-to-in-tech');
+    expect(openIds).not.toContain('research');
     expect(openIds).not.toContain('dev.to');
-    expect(openIds).not.toContain('coderlegion');
-    expect(openIds).not.toContain('generated');
   });
 });

--- a/tests/unit/surface-host.spec.ts
+++ b/tests/unit/surface-host.spec.ts
@@ -63,6 +63,11 @@ describe('isOpenSurfaceRoute', () => {
     expect(isPocketOnlyMarketingPath('/tools')).toBe(true);
     expect(isOpenSurfaceRoute('/features/google-drive-sync')).toBe(false);
     expect(isPocketOnlyMarketingPath('/features/google-drive-sync')).toBe(true);
+    expect(isOpenSurfaceRoute('/book/sovereign-intelligence')).toBe(false);
+    expect(isPocketOnlyMarketingPath('/book')).toBe(true);
+    expect(isPocketOnlyMarketingPath('/book/sovereign-intelligence')).toBe(true);
+    // Static book assets stay on Open (figures) — not the HTML book routes
+    expect(isPocketOnlyMarketingPath('/book-assets/covers/x.svg')).toBe(false);
   });
 
   it('denies other consumer-only paths without B2B rewrite', () => {


### PR DESCRIPTION
## Summary
- Open `/blog` lists only institutional B2B briefs; farm how-to/research stay off hub/sitemap; internal `sovereign-engineering-serial-*` diaries are delisted + noindex.
- Pocket `/blog` drops Dev.to and CoderLegion filters/cards; first-party deep-dives only.
- Open `/book/*` redirects to Pocket (fixes hard 404 on `openportfolio.co.uk/book/sovereign-intelligence`); MDX book links absolutized; Open unknown-route not-found keeps O. chrome.

## Test plan
- [ ] `https://www.openportfolio.co.uk/blog` shows 3 Abba briefs only
- [ ] `https://www.openportfolio.co.uk/book/sovereign-intelligence` → 307 to Pocket book URL (200)
- [ ] `https://www.pocketportfolio.app/blog` has no Dev.to / CoderLegion chips
- [ ] Open unknown path shows Open 404 copy (not Pocket root 404)
- [ ] Unit: `blog-surfaces`, `surface-host`, `open-sitemap`, `blog-sitemap-entries`