### PR TITLE
Raise Sovereign launch email blast capacity for Mon drop

### DIFF
--- a/app/api/cron/sovereign-ai-launch-blast/route.ts
+++ b/app/api/cron/sovereign-ai-launch-blast/route.ts
@@ -129,9 +129,9 @@ export async function GET(request: NextRequest) {
   const maxSendsFromQuery = limitParam != null && limitParam !== '' ? Number(limitParam) : NaN;
   const maxSends = Number.isFinite(maxSendsFromQuery)
     ? Math.max(0, Math.floor(maxSendsFromQuery))
-    : Number(process.env.SOVEREIGN_AI_LAUNCH_MAX_SENDS || 50);
+    : Number(process.env.SOVEREIGN_AI_LAUNCH_MAX_SENDS || 500);
 
-  const batchSleepMs = Number(process.env.SOVEREIGN_AI_LAUNCH_BATCH_SLEEP_MS || 1000);
+  const batchSleepMs = Number(process.env.SOVEREIGN_AI_LAUNCH_BATCH_SLEEP_MS || 400);
 
   const db = getDb();
   const auth = getAuth();


### PR DESCRIPTION
## Summary
- Production dry-run: **265** deduplicated recipients (107 users + 158 identityGateLeads)
- Raise default `maxSends` 50 → 500 and batch sleep 1000ms → 400ms so Monday’s single cron can finish within `maxDuration: 300`

## Test plan
- [ ] Deploy to production
- [ ] Optional re-dry-run confirms maxSends 500 in JSON