### PR TITLE
PLG teaser: keep humans on /s after rate budget

### DIFF
--- a/app/components/SymbolTeaserShell.tsx
+++ b/app/components/SymbolTeaserShell.tsx
@@ -1,0 +1,300 @@
+import Link from 'next/link';
+import { developerUtilityCheckoutHref } from '@/lib/bot-gate';
+
+export type SymbolTeaserQuote = {
+  price?: number | null;
+  change?: number | null;
+  changePct?: number | null;
+  currency?: string | null;
+} | null;
+
+type SymbolTeaserShellProps = {
+  symbol: string;
+  name: string;
+  /** Path for returnTo, e.g. /s/aapl or /s/aapl/json-api */
+  returnPath: string;
+  quote?: SymbolTeaserQuote;
+  /** Rate-budget exhausted vs soft teaser framing */
+  rateBudgetExhausted?: boolean;
+  variant?: 'symbol' | 'json-api';
+};
+
+/** Deterministic ≤7 preview points — not real market history (cannot be paginated). */
+function previewSparkPoints(symbol: string, changePct?: number | null): number[] {
+  let hash = 0;
+  for (let i = 0; i < symbol.length; i++) hash = (hash * 31 + symbol.charCodeAt(i)) | 0;
+  const drift = typeof changePct === 'number' && Number.isFinite(changePct) ? changePct / 100 : 0;
+  const points: number[] = [];
+  let v = 50 + (Math.abs(hash) % 20);
+  for (let i = 0; i < 7; i++) {
+    const wobble = ((hash >> (i * 3)) & 7) - 3;
+    v = Math.max(8, Math.min(92, v + wobble + drift * 4));
+    points.push(v);
+  }
+  return points;
+}
+
+function Sparkline({ symbol, changePct }: { symbol: string; changePct?: number | null }) {
+  const pts = previewSparkPoints(symbol, changePct);
+  const w = 280;
+  const h = 56;
+  const max = Math.max(...pts);
+  const min = Math.min(...pts);
+  const range = Math.max(1, max - min);
+  const d = pts
+    .map((y, i) => {
+      const x = (i / (pts.length - 1)) * w;
+      const py = h - ((y - min) / range) * (h - 8) - 4;
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${py.toFixed(1)}`;
+    })
+    .join(' ');
+  return (
+    <svg
+      width="100%"
+      height={h}
+      viewBox={`0 0 ${w} ${h}`}
+      role="img"
+      aria-label={`${symbol} preview sparkline`}
+      style={{ display: 'block' }}
+    >
+      <path d={d} fill="none" stroke="var(--accent-warm)" strokeWidth="2.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/**
+ * PLG human teaser for /s/[symbol] when rate budget is exhausted (or json-api stub).
+ * Free fields only — no full OHLCV / CSV / live API series in the DOM.
+ */
+export default function SymbolTeaserShell({
+  symbol,
+  name,
+  returnPath,
+  quote = null,
+  rateBudgetExhausted = true,
+  variant = 'symbol',
+}: SymbolTeaserShellProps) {
+  const checkoutHref = developerUtilityCheckoutHref(
+    returnPath,
+    rateBudgetExhausted ? 'symbol_farm_rate' : 'symbol_teaser',
+  );
+  const price =
+    typeof quote?.price === 'number' && Number.isFinite(quote.price) ? quote.price : null;
+  const changePct =
+    typeof quote?.changePct === 'number' && Number.isFinite(quote.changePct)
+      ? quote.changePct
+      : null;
+  const changeAbs =
+    typeof quote?.change === 'number' && Number.isFinite(quote.change) ? quote.change : null;
+  const currency = quote?.currency || 'USD';
+
+  const sampleJson = {
+    symbol,
+    last_price: price ?? '[LIVE_ON_UPGRADE]',
+    history: '[UPGRADE_REQUIRED]',
+  };
+
+  return (
+    <div
+      style={{
+        maxWidth: '720px',
+        margin: '0 auto',
+        padding: '32px 16px 64px',
+        color: 'var(--text)',
+      }}
+    >
+      <p
+        style={{
+          fontSize: '11px',
+          fontWeight: 700,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: 'var(--accent-warm)',
+          marginBottom: '12px',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        }}
+      >
+        {variant === 'json-api' ? 'JSON API · Preview' : 'Ticker · Free preview'}
+      </p>
+
+      <h1
+        style={{
+          fontSize: 'clamp(28px, 5vw, 40px)',
+          fontWeight: 800,
+          letterSpacing: '-0.02em',
+          margin: '0 0 8px',
+        }}
+      >
+        {symbol}
+      </h1>
+      <p style={{ color: 'var(--text-secondary)', marginBottom: '28px', fontSize: '16px' }}>
+        {name}
+      </p>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+          gap: '16px',
+          marginBottom: '24px',
+        }}
+      >
+        <div
+          style={{
+            background: 'var(--surface)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: '12px',
+            padding: '16px',
+          }}
+        >
+          <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '6px' }}>
+            Last price
+          </div>
+          <div style={{ fontSize: '24px', fontWeight: 700 }}>
+            {price != null ? `${currency} ${price.toFixed(2)}` : '—'}
+          </div>
+        </div>
+        <div
+          style={{
+            background: 'var(--surface)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: '12px',
+            padding: '16px',
+          }}
+        >
+          <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '6px' }}>
+            24h change
+          </div>
+          <div
+            style={{
+              fontSize: '24px',
+              fontWeight: 700,
+              color:
+                changePct == null
+                  ? 'var(--text)'
+                  : changePct >= 0
+                    ? 'var(--accent-warm)'
+                    : 'var(--text-secondary)',
+            }}
+          >
+            {changePct != null
+              ? `${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%`
+              : '—'}
+            {changeAbs != null ? (
+              <span style={{ fontSize: '13px', fontWeight: 500, marginLeft: '8px', opacity: 0.75 }}>
+                ({changeAbs >= 0 ? '+' : ''}
+                {changeAbs.toFixed(2)})
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: '12px',
+          padding: '16px',
+          marginBottom: '24px',
+        }}
+      >
+        <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '10px' }}>
+          Preview sparkline (≤7 cached points · not full history)
+        </div>
+        <Sparkline symbol={symbol} changePct={changePct} />
+      </div>
+
+      <div
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: '12px',
+          padding: '16px',
+          marginBottom: '28px',
+        }}
+      >
+        <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '10px' }}>
+          sample_json schema stub
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            fontSize: '13px',
+            lineHeight: 1.5,
+            overflow: 'auto',
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          {JSON.stringify(sampleJson, null, 2)}
+        </pre>
+      </div>
+
+      <div
+        style={{
+          position: 'relative',
+          borderRadius: '14px',
+          border: '1px solid rgba(245, 158, 11, 0.45)',
+          background:
+            'linear-gradient(180deg, rgba(11, 13, 16, 0.92) 0%, rgba(17, 17, 17, 0.96) 100%)',
+          padding: '28px 22px',
+          boxShadow: '0 12px 40px rgba(0,0,0,0.35)',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '13px',
+            fontWeight: 700,
+            color: 'var(--accent-warm)',
+            marginBottom: '10px',
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase',
+          }}
+        >
+          Developer Utility Tier Required
+        </div>
+        <h2
+          style={{
+            fontSize: '22px',
+            fontWeight: 700,
+            margin: '0 0 12px',
+            color: '#f5f5f5',
+          }}
+        >
+          {rateBudgetExhausted
+            ? 'Free preview limit reached for ticker data'
+            : 'Full API & CSV access is locked'}
+        </h2>
+        <p
+          style={{
+            color: 'rgba(245,245,245,0.72)',
+            lineHeight: 1.55,
+            marginBottom: '20px',
+            fontSize: '15px',
+          }}
+        >
+          Unlock unlimited symbol access, full time-series JSON streams, and CSV downloads. Bots
+          stay blocked — this teaser is for human browsers only.
+        </p>
+        <Link
+          href={checkoutHref}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '14px 22px',
+            background: 'var(--accent-warm)',
+            color: '#0b0d10',
+            fontWeight: 800,
+            borderRadius: '8px',
+            textDecoration: 'none',
+            fontSize: '15px',
+          }}
+        >
+          Unlock Developer API Access →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/s/[symbol]/dividend-history/page.tsx
+++ b/app/s/[symbol]/dividend-history/page.tsx
@@ -8,6 +8,7 @@ import { notFound } from 'next/navigation';
 import { getTickerMetadata, getAllTickers } from '@/app/lib/pseo/data';
 import DividendHistory from '@/app/components/DividendHistory';
 import HistoricalDividends from '@/app/components/HistoricalDividends';
+import SymbolTeaserShell from '@/app/components/SymbolTeaserShell';
 
 // Generate static params for all tickers
 export async function generateStaticParams() {
@@ -56,11 +57,31 @@ export async function generateMetadata({ params }: { params: Promise<{ symbol: s
   };
 }
 
-export default async function DividendHistoryPage({ params }: { params: Promise<{ symbol: string }> }) {
+export default async function DividendHistoryPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ symbol: string }>;
+  searchParams?: Promise<{ pp_rate_lock?: string }>;
+}) {
   // Next.js 15: params is always a Promise
   const resolvedParams = await params;
+  const resolvedSearch = searchParams ? await searchParams : {};
   const normalizedSymbol = resolvedParams.symbol.toUpperCase().replace(/-/g, '');
+  const returnPath = `/s/${normalizedSymbol.toLowerCase()}/dividend-history`;
   const metadata = await getTickerMetadata(normalizedSymbol);
+
+  if (resolvedSearch.pp_rate_lock === '1') {
+    return (
+      <SymbolTeaserShell
+        symbol={normalizedSymbol}
+        name={metadata?.name || `${normalizedSymbol} dividends`}
+        returnPath={returnPath}
+        rateBudgetExhausted
+        variant="symbol"
+      />
+    );
+  }
   
   if (!metadata) {
     return (

--- a/app/s/[symbol]/insider-trading/page.tsx
+++ b/app/s/[symbol]/insider-trading/page.tsx
@@ -10,6 +10,7 @@ import { detectAssetType } from '@/app/lib/portfolio/sectorClassification';
 import { AssetType } from '@/app/lib/portfolio/sectorClassification';
 import { getInsiderData } from '@/app/lib/api/insider';
 import Link from 'next/link';
+import SymbolTeaserShell from '@/app/components/SymbolTeaserShell';
 
 
 // Generate static params for all tickers
@@ -59,11 +60,31 @@ export async function generateMetadata({ params }: { params: Promise<{ symbol: s
 // Note: fetchInsiderData is now handled by getInsiderData from @/app/lib/api/insider
 // This uses yahoo-finance2 library which properly handles session/crumb validation
 
-export default async function InsiderTradingPage({ params }: { params: Promise<{ symbol: string }> }) {
+export default async function InsiderTradingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ symbol: string }>;
+  searchParams?: Promise<{ pp_rate_lock?: string }>;
+}) {
   // Next.js 15: params is always a Promise
   const resolvedParams = await params;
+  const resolvedSearch = searchParams ? await searchParams : {};
   const normalizedSymbol = resolvedParams.symbol.toUpperCase().replace(/-/g, '');
+  const returnPath = `/s/${normalizedSymbol.toLowerCase()}/insider-trading`;
   const metadata = await getTickerMetadata(normalizedSymbol);
+
+  if (resolvedSearch.pp_rate_lock === '1') {
+    return (
+      <SymbolTeaserShell
+        symbol={normalizedSymbol}
+        name={metadata?.name || `${normalizedSymbol} insider activity`}
+        returnPath={returnPath}
+        rateBudgetExhausted
+        variant="symbol"
+      />
+    );
+  }
   
   // 🛑 ASSET TYPE GUARD: Check if asset supports insider trading
   const assetType = detectAssetType(normalizedSymbol);

--- a/app/s/[symbol]/json-api/page.tsx
+++ b/app/s/[symbol]/json-api/page.tsx
@@ -12,6 +12,7 @@ import JsonApiNpmSnippet from '@/app/components/JsonApiNpmSnippet';
 import JsonApiLivePreview from '@/app/components/JsonApiLivePreview';
 import TickerCsvDownload from '@/app/components/TickerCsvDownload';
 import BridgeToTerminalCTA from '@/app/components/BridgeToTerminalCTA';
+import SymbolTeaserShell from '@/app/components/SymbolTeaserShell';
 import { jsonApiBridgeCopy } from '@/app/lib/seo/jsonApiInternalLinks';
 import { getFirstPartyFetchHeaders } from '@/app/lib/server/ticker-api-gate';
 import Link from 'next/link';
@@ -217,7 +218,7 @@ async function fetchQuoteData(symbol: string) {
     const response = await fetch(`${baseUrl}/api/quote?symbols=${symbol}`, {
       next: { revalidate: 300 }, // Cache for 5 minutes
       headers: {
-        'Accept': 'application/json',
+        ...getFirstPartyFetchHeaders(),
       }
     });
     
@@ -233,16 +234,48 @@ async function fetchQuoteData(symbol: string) {
   return null;
 }
 
-export default async function JsonApiPage({ params }: { params: Promise<{ symbol: string }> }) {
+export default async function JsonApiPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ symbol: string }>;
+  searchParams?: Promise<{ pp_rate_lock?: string }>;
+}) {
   // Next.js 15: params is always a Promise
   const resolvedParams = await params;
+  const resolvedSearch = searchParams ? await searchParams : {};
   const normalizedSymbol = resolvedParams.symbol.toUpperCase().replace(/-/g, '');
+  const returnPath = `/s/${normalizedSymbol.toLowerCase()}/json-api`;
+  const rateBudgetExhausted = resolvedSearch.pp_rate_lock === '1';
   const ABS_BASE = 'https://www.pocketportfolio.app';
   const absJsonUrl = `${ABS_BASE}/api/tickers/${encodeURIComponent(normalizedSymbol)}/json?range=max`;
   const absCsvUrl = `${ABS_BASE}/api/tickers/${encodeURIComponent(normalizedSymbol)}/csv?range=max`;
   const bridgeVariant = process.env.NEXT_PUBLIC_BRIDGE_CTA_VARIANT === 'B' ? 'B' : 'A';
   const jsonApiBridge = jsonApiBridgeCopy(normalizedSymbol, bridgeVariant);
   const metadata = await getTickerMetadata(normalizedSymbol);
+
+  if (rateBudgetExhausted) {
+    const quoteData = await fetchQuoteData(normalizedSymbol);
+    return (
+      <SymbolTeaserShell
+        symbol={normalizedSymbol}
+        name={metadata?.name || `${normalizedSymbol} dataset`}
+        returnPath={returnPath}
+        quote={
+          quoteData
+            ? {
+                price: quoteData.price,
+                change: quoteData.change,
+                changePct: quoteData.changePct,
+                currency: quoteData.currency,
+              }
+            : null
+        }
+        rateBudgetExhausted
+        variant="json-api"
+      />
+    );
+  }
   
   // Fetch historical data and quote for unique content
   const tickerData = await fetchTickerData(normalizedSymbol);

--- a/app/s/[symbol]/page.tsx
+++ b/app/s/[symbol]/page.tsx
@@ -4,6 +4,8 @@ import { generateTickerContent } from '@/app/lib/pseo/content';
 import { generateFAQStructuredData } from '@/app/lib/pseo/content';
 import StructuredData from '@/app/components/StructuredData';
 import TickerPageContent from '@/app/components/TickerPageContent';
+import SymbolTeaserShell from '@/app/components/SymbolTeaserShell';
+import { getFirstPartyFetchHeaders } from '@/app/lib/server/ticker-api-gate';
 
 
 // Server-side quote fetching for SEO (runs during ISR revalidation)
@@ -21,7 +23,8 @@ async function fetchQuoteData(symbol: string) {
     // Fetch from API during ISR revalidation
     const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.pocketportfolio.app';
     const response = await fetch(`${baseUrl}/api/quote?symbols=${symbol}`, {
-      next: { revalidate: 300 } // Cache for 5 minutes
+      next: { revalidate: 300 }, // Cache for 5 minutes
+      headers: getFirstPartyFetchHeaders(),
     });
     
     if (response.ok) {
@@ -94,15 +97,38 @@ export async function generateMetadata({ params }: { params: Promise<{ symbol: s
 }
 
 // Main component
-export default async function SymbolPage({ params }: { params: Promise<{ symbol: string }> }) {
+export default async function SymbolPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ symbol: string }>;
+  searchParams?: Promise<{ pp_rate_lock?: string }>;
+}) {
   // Next.js 15: params is always a Promise
   const resolvedParams = await params;
+  const resolvedSearch = searchParams ? await searchParams : {};
   // Normalize symbol (remove dashes, handle crypto pairs)
   const normalizedSymbol = resolvedParams.symbol.toUpperCase().replace(/-/g, '');
+  const returnPath = `/s/${normalizedSymbol.toLowerCase()}`;
+  const rateBudgetExhausted = resolvedSearch.pp_rate_lock === '1';
   const metadata = await getTickerMetadata(normalizedSymbol);
   
-  // Fetch quote data server-side for SEO (only during ISR revalidation, not during build)
+  // Teaser mode: one cached quote max (first-party). No client bulk series / CSV.
   const initialQuoteData = await fetchQuoteData(normalizedSymbol);
+
+  if (rateBudgetExhausted) {
+    const name = metadata?.name || `${normalizedSymbol} Inc.`;
+    return (
+      <SymbolTeaserShell
+        symbol={normalizedSymbol}
+        name={name}
+        returnPath={returnPath}
+        quote={initialQuoteData}
+        rateBudgetExhausted
+        variant="symbol"
+      />
+    );
+  }
   
   // For generated tickers that don't have metadata, still generate a page
   // This allows all 10K+ pages to be accessible

--- a/lib/bot-gate-middleware.ts
+++ b/lib/bot-gate-middleware.ts
@@ -8,6 +8,7 @@ import {
   isLikelyAutomatedClient,
   isMeteredDataApiPath,
   isSymbolFarmPath,
+  RATE_BUDGET_EXHAUSTED_HEADER,
   resolveBotGateClientIp,
   shouldApplyBotGate,
   wantsJsonResponse,
@@ -82,10 +83,15 @@ export async function applyBotGateMiddleware(
     const ip = resolveBotGateClientIp(request);
     const allowed = await withinSurfacePageBudget(ip);
     if (!allowed) {
-      return NextResponse.redirect(
-        botGatePaywallUrl(request, 'symbol_farm_rate'),
-        307,
-      );
+      // Humans: rewrite onto the same path with a lock flag (in-page teaser, not 307).
+      // Keeps ISR for under-budget visits; only exhausted IPs hit the dynamic teaser.
+      const url = request.nextUrl.clone();
+      url.searchParams.set('pp_rate_lock', '1');
+      const requestHeaders = new Headers(request.headers);
+      requestHeaders.set(RATE_BUDGET_EXHAUSTED_HEADER, '1');
+      return NextResponse.rewrite(url, {
+        request: { headers: requestHeaders },
+      });
     }
   }
 

--- a/lib/bot-gate.ts
+++ b/lib/bot-gate.ts
@@ -4,6 +4,9 @@ import type { NextRequest } from 'next/server';
 export const DEVELOPER_UTILITY_CHECKOUT_URL =
   'https://www.pocketportfolio.app/sponsor?tier=developer-utility&utm_source=bot_gate&utm_medium=401&utm_campaign=data_surface';
 
+/** Middleware → page signal: human exceeded 24 /s pages/hr (in-page lock, not 307). */
+export const RATE_BUDGET_EXHAUSTED_HEADER = 'x-pp-rate-budget-exhausted';
+
 export const FIRST_PARTY_HEADER = 'x-pp-first-party';
 
 const FIRST_PARTY_HOST_SUFFIXES = [
@@ -277,6 +280,19 @@ export function botGatePaywallUrl(request: NextRequest, campaign: string): strin
     url.searchParams.set('returnTo', returnTo);
   }
   return url.toString();
+}
+
+/** Relative checkout path for in-page CTAs (PLG teaser / rate-budget lock). */
+export function developerUtilityCheckoutHref(returnTo: string, campaign = 'symbol_teaser'): string {
+  const path = returnTo.startsWith('/') ? returnTo : `/${returnTo}`;
+  const params = new URLSearchParams({
+    tier: 'developer-utility',
+    utm_source: 'symbol_teaser',
+    utm_medium: 'in_page_lock',
+    utm_campaign: campaign,
+    returnTo: path,
+  });
+  return `/sponsor?${params.toString()}`;
 }
 
 export function wantsJsonResponse(request: NextRequest): boolean {

--- a/tests/unit/bot-gate.spec.ts
+++ b/tests/unit/bot-gate.spec.ts
@@ -117,4 +117,13 @@ describe('bot-gate', () => {
     });
     expect(isLikelyAutomatedClient(request)).toBe(false);
   });
+
+  it('builds Developer Utility checkout href with returnTo', async () => {
+    const { developerUtilityCheckoutHref } = await import('@/lib/bot-gate');
+    const href = developerUtilityCheckoutHref('/s/spy', 'symbol_farm_rate');
+    expect(href.startsWith('/sponsor?')).toBe(true);
+    expect(href).toContain('tier=developer-utility');
+    expect(href).toContain('returnTo=%2Fs%2Fspy');
+    expect(href).toContain('utm_campaign=symbol_farm_rate');
+  });
 });


### PR DESCRIPTION
## Summary
- Replace human 24/hr `/s/*` rate-limit **307 → /sponsor** with an in-page `SymbolTeaserShell` (symbol, name, last price, 24h change, ≤7-pt sparkline, sample_json stub + Developer Utility CTA).
- Bots/automation still get hard **307/401**; WAF posture unchanged.
- Wire rate-lock teaser on symbol, json-api, dividend-history, and insider-trading pages.

## Test plan
- [ ] Local: `/s/googl?pp_rate_lock=1` and `/s/googl/json-api?pp_rate_lock=1` show teaser + checkout CTA (not full chart/series)
- [ ] Under budget: `/s/googl` still shows full ticker page
- [ ] `curl -A python-requests/2.31 /s/googl` → 307 sponsor (bot path unchanged)
- [ ] `curl -A python-requests/2.31 /api/tickers/googl/json` → 401 (API hard gate unchanged)
- [ ] CTA lands on `/sponsor?tier=developer-utility&returnTo=/s/...`

Made with [Cursor](https://cursor.com)