### PR TITLE
API 402 teaser: close unpaid OHLCV backdoor

### DIFF
--- a/app/api/price/[ticker]/route.ts
+++ b/app/api/price/[ticker]/route.ts
@@ -10,7 +10,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ ticker: string }> },
 ) {
-  const gate = await enforceDataApiGate(request);
+  const gate = await enforceDataApiGate(request, { surface: 'series' });
   if (!gate.allowed) return gate.response;
 
   const resolvedParams = await params;

--- a/app/api/tickers/[...ticker]/route.ts
+++ b/app/api/tickers/[...ticker]/route.ts
@@ -2,18 +2,15 @@
  * Ticker Historical Data JSON/CSV API
  * GET /api/tickers/{ticker}/json|csv
  *
- * First-party HTML UI is free (same-origin / SSR secret).
- * External unauthenticated traffic is KV-metered; automated clients require a paid API key.
- * Upsell: Developer Utility Stripe deep-link.
+ * Full series: paid `pp_` key or verified first-party (SSR secret / trusted app).
+ * Unpaid human browsers → 402 sales stub. Automated clients → 401. No free OHLCV.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getTickerMetadata } from '@/app/lib/pseo/data';
 import {
   DEVELOPER_UTILITY_CHECKOUT_URL,
-  rateLimitExceededCsvBody,
   tickerApiBaseHeaders,
-  unauthorizedCsvBody,
 } from '@/app/lib/server/ticker-api-gate';
 import { enforceDataApiGate } from '@/app/lib/server/data-api-gate';
 
@@ -419,23 +416,9 @@ export async function GET(
     );
   }
   
-  // Bot gate: automated → 401; symbol-farm referrers → tight KV bucket; trusted app UI exempt
-  const gate = await enforceDataApiGate(request);
+  // Series vault: paid key / first-party → 200; unpaid human → 402 stub; bot → 401
+  const gate = await enforceDataApiGate(request, { surface: 'series' });
   if (!gate.allowed) {
-    const status = gate.response.status;
-    if (format === 'csv') {
-      const retryAfter = Number(gate.response.headers.get('Retry-After') || '3600');
-      const body =
-        status === 401 ? unauthorizedCsvBody() : rateLimitExceededCsvBody(retryAfter);
-      return new NextResponse(body, {
-        status,
-        headers: withTickerHeaders({
-          'Content-Type': 'text/csv; charset=utf-8',
-          'Content-Disposition': `attachment; filename="${ticker}-api-gate.csv"`,
-          ...(status === 429 ? { 'Retry-After': String(retryAfter) } : {}),
-        }),
-      });
-    }
     return gate.response;
   }
 

--- a/app/lib/server/data-api-gate.ts
+++ b/app/lib/server/data-api-gate.ts
@@ -10,16 +10,32 @@ import {
   resolveBotGateClientIp,
 } from '@/lib/bot-gate';
 import {
+  paymentRequiredCsvBody,
+  paymentRequiredHtmlBody,
+  paymentRequiredJsonBody,
+  prefersHtmlPaymentPage,
   rateLimitExceededJsonBody,
   tickerApiBaseHeaders,
+  unauthorizedCsvBody,
   unauthorizedJsonBody,
 } from '@/app/lib/server/ticker-api-gate';
 
 const DEMO_KEY = 'demo_key';
 const WINDOW_SECONDS = 3600;
+/** Soft meter for non-series surfaces (quote, dividend) — not full OHLCV vault. */
 const FREE_TIER_LIMIT = 50;
 const DATACENTER_LIMIT = 12;
 const SYMBOL_FARM_LIMIT = 6;
+
+export type DataApiGateSurface = 'series' | 'metered';
+
+export type DataApiGateOptions = {
+  /**
+   * `series` — /api/tickers/* + /api/price/* : zero free full payloads.
+   * `metered` — quote/dividend soft KV buckets (no bulk OHLCV dump).
+   */
+  surface?: DataApiGateSurface;
+};
 
 export type DataApiGateResult =
   | { allowed: true; hasValidApiKey: boolean }
@@ -64,7 +80,6 @@ async function checkKvRateLimit(
   limit: number,
 ): Promise<{ allowed: boolean; retryAfter: number }> {
   const key = `ratelimit:data-api:${bucket}:${ip}:${limit}`;
-  const now = Math.floor(Date.now() / 1000);
 
   try {
     const current = (await kv.get<number>(key)) || 0;
@@ -89,10 +104,52 @@ function gateHeaders(extra: Record<string, string> = {}): Record<string, string>
   return { ...tickerApiBaseHeaders(), ...extra };
 }
 
-function unauthorizedResponse(): NextResponse {
+function wantsCsv(request: NextRequest): boolean {
+  const path = request.nextUrl.pathname.toLowerCase();
+  if (path.endsWith('/csv') || path.includes('/csv')) return true;
+  const format = (request.nextUrl.searchParams.get('format') || '').toLowerCase();
+  return format === 'csv';
+}
+
+function unauthorizedResponse(request: NextRequest): NextResponse {
+  if (wantsCsv(request)) {
+    return new NextResponse(unauthorizedCsvBody(), {
+      status: 401,
+      headers: gateHeaders({
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Cache-Control': 'no-store',
+      }),
+    });
+  }
   return NextResponse.json(unauthorizedJsonBody(), {
     status: 401,
-    headers: gateHeaders(),
+    headers: gateHeaders({ 'Cache-Control': 'no-store' }),
+  });
+}
+
+function paymentRequiredResponse(request: NextRequest): NextResponse {
+  const symbol = extractTickerFromDataApiPath(request.nextUrl.pathname);
+  if (wantsCsv(request)) {
+    return new NextResponse(paymentRequiredCsvBody(symbol), {
+      status: 402,
+      headers: gateHeaders({
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Cache-Control': 'no-store',
+      }),
+    });
+  }
+  if (prefersHtmlPaymentPage(request)) {
+    return new NextResponse(paymentRequiredHtmlBody(symbol), {
+      status: 402,
+      headers: gateHeaders({
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-store',
+      }),
+    });
+  }
+  return NextResponse.json(paymentRequiredJsonBody(symbol), {
+    status: 402,
+    headers: gateHeaders({ 'Cache-Control': 'no-store' }),
   });
 }
 
@@ -106,20 +163,48 @@ function rateLimitedResponse(retryAfter: number): NextResponse {
       status: 429,
       headers: gateHeaders({
         'Retry-After': String(Math.max(1, retryAfter)),
+        'Cache-Control': 'no-store',
       }),
     },
   );
 }
 
+/** Pull symbol from /api/tickers/{SYM}/… or /api/price/{SYM}. */
+export function extractTickerFromDataApiPath(pathname: string): string | null {
+  const tickers = pathname.match(/^\/api\/tickers\/([^/]+)/i);
+  if (tickers?.[1]) {
+    try {
+      return decodeURIComponent(tickers[1]).toUpperCase();
+    } catch {
+      return tickers[1].toUpperCase();
+    }
+  }
+  const price = pathname.match(/^\/api\/price\/([^/]+)/i);
+  if (price?.[1]) {
+    try {
+      return decodeURIComponent(price[1]).toUpperCase();
+    } catch {
+      return price[1].toUpperCase();
+    }
+  }
+  return null;
+}
+
 /**
- * Enforce paid-key / rate-limit policy on market data APIs.
- * Automated clients always need a key. Symbol-farm referrers get a tight bucket.
+ * Enforce paid-key / first-party policy on market data APIs.
+ * `series` surfaces never emit full OHLCV without a key (human → 402 stub, bot → 401).
  */
 export async function enforceDataApiGate(
   request: NextRequest,
+  options: DataApiGateOptions = {},
 ): Promise<DataApiGateResult> {
+  const surface: DataApiGateSurface = options.surface ?? 'metered';
   const isDevelopment = process.env.NODE_ENV === 'development';
-  if (isDevelopment) return { allowed: true, hasValidApiKey: false };
+
+  // Soft surfaces keep local DX bypass; series vault is always locked (incl. localhost).
+  if (isDevelopment && surface === 'metered') {
+    return { allowed: true, hasValidApiKey: false };
+  }
 
   const apiKey = extractApiKeyFromRequest(request);
   const hasValidApiKey = apiKey ? await validatePaidApiKey(apiKey) : false;
@@ -129,11 +214,16 @@ export async function enforceDataApiGate(
   const isFirstParty = isFirstPartyTickerRequest(request);
 
   if (isAutomated) {
-    return { allowed: false, response: unauthorizedResponse() };
+    return { allowed: false, response: unauthorizedResponse(request) };
   }
 
   if (isFirstParty) {
     return { allowed: true, hasValidApiKey: false };
+  }
+
+  // Unpaid human on OHLCV/price vault → sales stub (never full series).
+  if (surface === 'series') {
+    return { allowed: false, response: paymentRequiredResponse(request) };
   }
 
   const ip = resolveBotGateClientIp(request);

--- a/app/lib/server/ticker-api-gate.ts
+++ b/app/lib/server/ticker-api-gate.ts
@@ -92,3 +92,123 @@ export function unauthorizedCsvBody(): string {
     `${day},"API key required for automated extraction. Upgrade to Developer Utility.",${checkout}`,
   ].join('\n');
 }
+
+/** Deterministic synthetic close — not live market data (cannot be paginated into history). */
+export function syntheticPreviewClose(symbol: string): number {
+  let hash = 0;
+  for (let i = 0; i < symbol.length; i++) hash = (hash * 31 + symbol.charCodeAt(i)) | 0;
+  return Math.round((40 + (Math.abs(hash) % 20000) / 100) * 100) / 100;
+}
+
+/** Unpaid human browser stub for OHLCV / price series (HTTP 402). */
+export function paymentRequiredJsonBody(symbol?: string | null) {
+  const sym = (symbol || 'SYMBOL').toUpperCase().replace(/[^A-Z0-9.\-^=]/gi, '') || 'SYMBOL';
+  const returnTo = `/s/${sym.toLowerCase()}`;
+  const close = syntheticPreviewClose(sym);
+  const day0 = new Date();
+  const iso = (d: Date) => d.toISOString().split('T')[0];
+  const d0 = iso(day0);
+  const d1 = iso(new Date(day0.getTime() - 86400000));
+  const d2 = iso(new Date(day0.getTime() - 172800000));
+  const checkout = new URL(
+    `${DEVELOPER_UTILITY_CHECKOUT_URL.split('?')[0]}?tier=developer-utility`,
+  );
+  checkout.searchParams.set('utm_source', 'api_series_gate');
+  checkout.searchParams.set('utm_medium', '402');
+  checkout.searchParams.set('utm_campaign', 'ticker_api');
+  checkout.searchParams.set('returnTo', returnTo);
+
+  return {
+    status: 'payment_required',
+    message: 'Developer Tier required for full OHLCV and price series.',
+    preview: {
+      symbol: sym,
+      schema: ['date', 'open', 'high', 'low', 'close', 'volume'],
+      sample: [
+        { date: d0, close },
+        { date: d1, close: Math.round(close * 0.997 * 100) / 100 },
+        { date: d2, close: Math.round(close * 0.994 * 100) / 100 },
+      ],
+      total_records_locked: '[UPGRADE_REQUIRED]',
+    },
+    checkout_url: checkout.toString(),
+  };
+}
+
+export function paymentRequiredCsvBody(symbol?: string | null): string {
+  const body = paymentRequiredJsonBody(symbol);
+  const day = new Date().toISOString().split('T')[0];
+  return [
+    'Date,Error,Status,CheckoutUrl',
+    `${day},"${body.message}",payment_required,${body.checkout_url}`,
+  ].join('\n');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Browser address-bar navigations get a clickable HTML lock page.
+ * API clients (Accept JSON / XHR) keep the structured 402 JSON stub.
+ */
+export function paymentRequiredHtmlBody(symbol?: string | null): string {
+  const body = paymentRequiredJsonBody(symbol);
+  const sym = escapeHtml(String(body.preview.symbol));
+  const message = escapeHtml(body.message);
+  const checkout = escapeHtml(body.checkout_url);
+  const sampleJson = escapeHtml(JSON.stringify(body.preview.sample, null, 2));
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>${sym} API · Developer Tier Required</title>
+  <style>
+    :root { color-scheme: dark; --bg:#0b0d10; --surface:#111; --text:#f5f5f5; --muted:#a3a3a3; --accent:#f59e0b; --border:rgba(255,255,255,0.12); }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; background:radial-gradient(1200px 600px at 20% -10%, rgba(245,158,11,0.12), transparent), var(--bg); color:var(--text); }
+    main { max-width:720px; margin:0 auto; padding:48px 20px 72px; }
+    .eyebrow { font:700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing:0.08em; text-transform:uppercase; color:var(--accent); margin-bottom:12px; }
+    h1 { font-size:clamp(28px,5vw,40px); letter-spacing:-0.02em; margin:0 0 10px; }
+    p { color:var(--muted); line-height:1.55; margin:0 0 24px; }
+    .card { background:var(--surface); border:1px solid var(--border); border-radius:12px; padding:16px; margin-bottom:20px; }
+    pre { margin:0; overflow:auto; font:13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; color:#d4d4d4; }
+    .cta { display:inline-flex; align-items:center; justify-content:center; padding:14px 22px; background:var(--accent); color:#0b0d10; font-weight:800; border-radius:8px; text-decoration:none; }
+    .cta:hover { filter:brightness(1.05); }
+    .meta { margin-top:18px; font-size:12px; color:var(--muted); word-break:break-all; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="eyebrow">JSON API · Payment required</div>
+    <h1>${sym}</h1>
+    <p>${message}</p>
+    <div class="card">
+      <div style="font-size:12px;color:var(--muted);margin-bottom:10px">Preview sample (≤3 points · not full history)</div>
+      <pre>${sampleJson}</pre>
+    </div>
+    <a class="cta" href="${checkout}">Unlock Developer API Access →</a>
+    <p class="meta">Programmatic clients receive <code>application/json</code> 402 with <code>checkout_url</code>.</p>
+  </main>
+</body>
+</html>`;
+}
+
+/** True when a human opened the API URL in the browser (not XHR/curl JSON clients). */
+export function prefersHtmlPaymentPage(request: {
+  headers: { get(name: string): string | null };
+}): boolean {
+  const dest = (request.headers.get('sec-fetch-dest') || '').toLowerCase();
+  if (dest === 'document') return true;
+  const mode = (request.headers.get('sec-fetch-mode') || '').toLowerCase();
+  const accept = (request.headers.get('accept') || '').toLowerCase();
+  if (mode === 'navigate' && accept.includes('text/html')) return true;
+  return false;
+}

--- a/tests/unit/data-api-gate.spec.ts
+++ b/tests/unit/data-api-gate.spec.ts
@@ -1,0 +1,167 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@vercel/kv', () => ({
+  kv: {
+    get: vi.fn(async () => 0),
+    set: vi.fn(async () => 'OK'),
+    ttl: vi.fn(async () => 3600),
+  },
+}));
+
+vi.mock('firebase-admin/app', () => ({
+  initializeApp: vi.fn(),
+  getApps: vi.fn(() => [{}]),
+  cert: vi.fn((v) => v),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  getFirestore: vi.fn(() => ({
+    collection: () => ({
+      where: () => ({
+        limit: () => ({
+          get: async () => ({ empty: true }),
+        }),
+      }),
+    }),
+  })),
+}));
+
+function req(url: string, init?: { headers?: Record<string, string> }) {
+  return new NextRequest(url, {
+    headers: init?.headers,
+  });
+}
+
+const chromeHuman = {
+  'user-agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  accept: 'text/html,application/xhtml+xml,application/json',
+  'sec-fetch-mode': 'navigate',
+  'sec-fetch-site': 'none',
+  'sec-fetch-dest': 'document',
+};
+
+describe('data-api-gate series surface', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'production');
+  });
+
+  it('returns HTML lock page with clickable CTA for browser document navigation', async () => {
+    const { enforceDataApiGate } = await import('@/app/lib/server/data-api-gate');
+    const result = await enforceDataApiGate(
+      req('https://www.pocketportfolio.app/api/tickers/googl/json?range=max', {
+        headers: chromeHuman,
+      }),
+      { surface: 'series' },
+    );
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.response.status).toBe(402);
+    expect(result.response.headers.get('content-type')).toContain('text/html');
+    const html = await result.response.text();
+    expect(html).toContain('Unlock Developer API Access');
+    expect(html).toContain('href="https://www.pocketportfolio.app/sponsor?tier=developer-utility');
+    expect(html).toContain('GOOGL');
+  });
+
+  it('returns 402 JSON stub for unpaid human JSON clients', async () => {
+    const { enforceDataApiGate } = await import('@/app/lib/server/data-api-gate');
+    const result = await enforceDataApiGate(
+      req('https://www.pocketportfolio.app/api/tickers/googl/json?range=max', {
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+          accept: 'application/json',
+          'sec-fetch-mode': 'cors',
+          'sec-fetch-site': 'cross-site',
+          'sec-fetch-dest': 'empty',
+        },
+      }),
+      { surface: 'series' },
+    );
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.response.status).toBe(402);
+    const body = await result.response.json();
+    expect(body.status).toBe('payment_required');
+    expect(body.preview.symbol).toBe('GOOGL');
+    expect(Array.isArray(body.preview.sample)).toBe(true);
+    expect(body.preview.sample.length).toBeLessThanOrEqual(3);
+    expect(body.checkout_url).toContain('tier=developer-utility');
+    expect(body.checkout_url).toContain('returnTo');
+  });
+
+  it('returns 401 for automated clients with no teaser sample series', async () => {
+    const { enforceDataApiGate } = await import('@/app/lib/server/data-api-gate');
+    const result = await enforceDataApiGate(
+      req('https://www.pocketportfolio.app/api/tickers/googl/json?range=max', {
+        headers: { 'user-agent': 'python-requests/2.31.0', accept: 'application/json' },
+      }),
+      { surface: 'series' },
+    );
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.response.status).toBe(401);
+    const body = await result.response.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(body.preview).toBeUndefined();
+  });
+
+  it('allows first-party SSR secret through', async () => {
+    vi.stubEnv('PP_FIRST_PARTY_FETCH_SECRET', 'test-secret');
+    const { enforceDataApiGate } = await import('@/app/lib/server/data-api-gate');
+    const { FIRST_PARTY_HEADER } = await import('@/lib/bot-gate');
+    const result = await enforceDataApiGate(
+      req('https://www.pocketportfolio.app/api/tickers/googl/json?range=max', {
+        headers: {
+          ...chromeHuman,
+          [FIRST_PARTY_HEADER]: 'test-secret',
+        },
+      }),
+      { surface: 'series' },
+    );
+    expect(result.allowed).toBe(true);
+  });
+
+  it('allows trusted dashboard referrer through', async () => {
+    const { enforceDataApiGate } = await import('@/app/lib/server/data-api-gate');
+    const result = await enforceDataApiGate(
+      req('https://www.pocketportfolio.app/api/tickers/SPY/json?range=1y', {
+        headers: {
+          ...chromeHuman,
+          'sec-fetch-site': 'same-origin',
+          'sec-fetch-mode': 'cors',
+          origin: 'https://www.pocketportfolio.app',
+          referer: 'https://www.pocketportfolio.app/dashboard',
+        },
+      }),
+      { surface: 'series' },
+    );
+    expect(result.allowed).toBe(true);
+  });
+
+  it('returns 402 CSV stub for unpaid human on csv format', async () => {
+    const { enforceDataApiGate } = await import('@/app/lib/server/data-api-gate');
+    const result = await enforceDataApiGate(
+      req('https://www.pocketportfolio.app/api/tickers/aapl/csv?range=max', {
+        headers: chromeHuman,
+      }),
+      { surface: 'series' },
+    );
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.response.status).toBe(402);
+    const text = await result.response.text();
+    expect(text).toContain('payment_required');
+    expect(text).toContain('CheckoutUrl');
+  });
+
+  it('extracts ticker from price and tickers paths', async () => {
+    const { extractTickerFromDataApiPath } = await import('@/app/lib/server/data-api-gate');
+    expect(extractTickerFromDataApiPath('/api/tickers/googl/json')).toBe('GOOGL');
+    expect(extractTickerFromDataApiPath('/api/price/MSFT')).toBe('MSFT');
+  });
+});


### PR DESCRIPTION
## Summary
- Eliminate free full-series KV quotas on `/api/tickers/*` and `/api/price/*`.
- Unpaid JSON clients → **402** stub (≤3 synthetic points + `checkout_url`).
- Unpaid browser document navigations → **402 HTML** lock page with clickable Developer Utility CTA.
- Automated clients → **401** (no curiosity preview).
- Paid `pp_` keys and first-party SSR / trusted app referrers → full **200**.

## Test plan
- [ ] Browser address bar: `/api/tickers/googl/json?range=max` → HTML lock + clickable Unlock CTA
- [ ] `curl -H "Accept: application/json"` unpaid → 402 JSON stub
- [ ] `curl -A python-requests/2.31` → 401
- [ ] Dashboard same-origin fetch still loads series
- [ ] SSR first-party secret still allows teaser fetches

Made with [Cursor](https://cursor.com)