### PR TITLE
Fix Sovereign multi-user soft-launch capacity

### DIFF
--- a/app/api/ai/sovereign/wake/route.ts
+++ b/app/api/ai/sovereign/wake/route.ts
@@ -1,7 +1,7 @@
 /**
  * POST /api/ai/sovereign/wake — wake-on-ask for OP-Hosted Sovereign PAYG.
- * Idle remains workersMin=0 ($0). This only spins a worker when the user
- * selects Sovereign or is about to send. Does not touch portfolio payload.
+ * Idle soft-launch: workersMin=1 keeps one warm worker; still PAYG beyond that.
+ * This only spins additional capacity when the user selects Sovereign or is about to send.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuth } from 'firebase-admin/auth';
@@ -16,8 +16,8 @@ import {
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
-/** Allow wake budget + margin (Vercel Pro). */
-export const maxDuration = 200;
+/** Soft-launch: wake budget is short; Cloud Auto safety net is the UX contract. */
+export const maxDuration = 45;
 
 function initializeFirebaseAdmin() {
   if (!getApps().length) {
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     if (body.provider && isLocalProviderMode(body.provider as AskAiProviderMode)) {
       provider = body.provider as AskAiProviderMode;
     }
-    if (typeof body.budgetMs === 'number' && body.budgetMs >= 5_000 && body.budgetMs <= 180_000) {
+    if (typeof body.budgetMs === 'number' && body.budgetMs >= 5_000 && body.budgetMs <= 60_000) {
       budgetMs = Math.floor(body.budgetMs);
     }
   } catch {
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
       waitedMs: result.waitedMs,
       probes: result.probes,
       provider,
-      idlePolicy: 'workersMin=0',
+      idlePolicy: 'soft_launch_workersMin=1_workersMax=5',
     },
     {
       status: result.warm ? 200 : 503,

--- a/app/components/ai/AskAIModal.tsx
+++ b/app/components/ai/AskAIModal.tsx
@@ -362,7 +362,7 @@ export function AskAIModal({
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId
-              ? { ...m, content: 'Waking OP-Hosted Sovereign GPU (idle was $0)…' }
+              ? { ...m, content: 'Waking OP-Hosted Sovereign…' }
               : m
           )
         );
@@ -374,7 +374,7 @@ export function AskAIModal({
       }
 
       const abort = new AbortController();
-      const timeoutMs = localModeActive ? SOVEREIGN_WAKE_BUDGET_MS + 90_000 : 20_000;
+      const timeoutMs = localModeActive ? SOVEREIGN_WAKE_BUDGET_MS + 95_000 : 20_000;
       const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
       let res: Response;
       try {
@@ -690,7 +690,7 @@ export function AskAIModal({
                   {localModeActive
                     ? isOllamaClientDirectEnabled()
                       ? 'BYO laptop Ollama: bounded summary goes to your local node (not third-party cloud APIs). Attachments disabled in Phase 1.'
-                      : 'OP-Hosted Sovereign wake-on-ask: idle GPU is $0. Selecting Sovereign or sending a question wakes the PAYG node; answers stay on-node when wake succeeds.'
+                      : 'OP-Hosted Sovereign: soft-launch keeps a warm GPU ready. If wake is slow, Cloud Auto answers so you are never stranded.'
                     : 'Ask about your portfolio, markets, or investing. Your data stays local; only a summary is sent to the AI.'}
                 </p>
               )}
@@ -707,7 +707,7 @@ export function AskAIModal({
                     ? '● Localhost BYO · experimental'
                     : wakingSovereign
                       ? '● Waking Sovereign GPU…'
-                      : '● OP-Hosted Sovereign · wake-on-ask · $0 idle'}
+                      : '● OP-Hosted Sovereign · soft-launch warm'}
                 </p>
               )}
               {messages.map((m) => {

--- a/app/lib/ai/providers/ollama.ts
+++ b/app/lib/ai/providers/ollama.ts
@@ -33,10 +33,10 @@ export async function checkOllamaHealth(baseUrl: string): Promise<boolean> {
   }
 }
 
-/** Default wake budget: poll until worker answers /models (idle $0 until ask). */
-export const SOVEREIGN_WAKE_BUDGET_MS = 180_000;
-export const SOVEREIGN_WAKE_PROBE_MS = 12_000;
-export const SOVEREIGN_WAKE_INTERVAL_MS = 2_000;
+/** Soft-launch wake budget: fail fast to Cloud Auto (do not strand users for 3 min). */
+export const SOVEREIGN_WAKE_BUDGET_MS = 25_000;
+export const SOVEREIGN_WAKE_PROBE_MS = 8_000;
+export const SOVEREIGN_WAKE_INTERVAL_MS = 1_500;
 
 export type WaitForOllamaWarmResult = {
   warm: boolean;

--- a/docs/command/sovereign-latency-contract-2026-08-04.md
+++ b/docs/command/sovereign-latency-contract-2026-08-04.md
@@ -53,9 +53,10 @@ First request after attaching the volume still populates the cache once. Later c
 
 | Path | Behavior |
 |------|----------|
-| Sovereign selected | Speculative **wake-on-ask** (`POST /api/ai/sovereign/wake`) — still `workersMin=0` until then |
-| Sovereign Send + node warming | Poll `/models` up to ~180s; complete on-node; `X-Pocket-Sovereign-Wake-Ms` |
+| Sovereign selected | Speculative **wake-on-ask** (`POST /api/ai/sovereign/wake`) |
+| Sovereign Send + node warming | Poll `/models` up to **~25s** soft-launch; then Cloud Auto |
 | Wake budget exhausted / on-node error | Cloud Auto **safety net**; `X-Pocket-Inference: cloud_auto_fallback` |
-| Idle GPU | `workersMin=0` — **$0**; `idleTimeout=600s` after last use |
+| Soft-launch capacity (2026-08-07) | `workersMin=1`, `workersMax=5`, `idleTimeout=600` — see `sovereign-soft-launch-capacity-2026-08-07.md` |
+| Idle GPU (post soft-launch target) | `workersMin=0` — **$0** when traffic allows |
 
-Vercel `maxDuration` for chat/wake is **200s**. Idle cost strategy unchanged.
+Vercel wake route `maxDuration` is **45s**. Chat remains longer for on-node complete + cloud fallback.

--- a/docs/command/sovereign-payg-mandate-lock-2026-08-04.md
+++ b/docs/command/sovereign-payg-mandate-lock-2026-08-04.md
@@ -13,7 +13,7 @@ date: 2026-08-04
 
 | Allowed | Forbidden |
 |---------|-----------|
-| RunPod **Serverless** `workersMin: 0`, `workersMax: 1`, `idleTimeout: 5` | Always-on **Pods** |
+| RunPod **Serverless** soft-launch: `workersMin: 1`, `workersMax: 5`, `idleTimeout: 600` | Always-on **Pods**; `workersMax: 1` (serializes all users) |
 | Per-second GPU while serving | Idle GPU burn / Pinggy-as-prod |
 | Prepaid wallet | “Customers download local models” |
 

--- a/docs/command/sovereign-soft-launch-capacity-2026-08-07.md
+++ b/docs/command/sovereign-soft-launch-capacity-2026-08-07.md
@@ -1,0 +1,30 @@
+---
+id: OP-CMD-SOVEREIGN-SOFT-LAUNCH-CAPACITY-2026-08-07
+title: Soft-launch Sovereign capacity — multi-user fix
+status: LIVE
+date: 2026-08-07
+endpoint: sci7vw5ovb0xnd (op-sovereign-r1)
+---
+
+# Soft-launch capacity fix (CEO)
+
+## Why leadership’s 180s budget was wrong for brand UX
+
+`SOVEREIGN_WAKE_BUDGET_MS = 180s` was a **safety ceiling** for a single cold PAYG boot under `workersMax: 1` — not an accepted wait for 100 concurrent users. With one worker, N Sovereign asks **serialize**; each client burns the wake budget in a queue. That is a capacity bug, not a product feature.
+
+**Accepted product rule (unchanged):** customers must not wait ~minutes. Warm Sovereign ≈ cloud. Idle cost savings ≠ user-facing cold-start theatre.
+
+## Live RunPod posture (2026-08-07)
+
+| Setting | Was (mandate lock) | Soft launch now |
+|---------|-------------------|-----------------|
+| `workersMin` | 0 | **1** (one warm worker — first ask should not cold-boot) |
+| `workersMax` | 1 | **5** (concurrent Sovereign without single-GPU stampede) |
+| `idleTimeout` | 600 | **600** |
+| App wake budget | 180s | **25s** then **Cloud Auto safety net** |
+
+Script: `node scripts/ops-soft-launch-sovereign-capacity.mjs`
+
+## Post soft-launch
+
+Revert `workersMin → 0` when traffic is quiet **only if** volume-cached cold is proven &lt; ~15s. Keep `workersMax ≥ 3` for multi-user. Do not restore `workersMax: 1`.

--- a/scripts/ops-soft-launch-sovereign-capacity.mjs
+++ b/scripts/ops-soft-launch-sovereign-capacity.mjs
@@ -1,0 +1,100 @@
+/**
+ * Soft-launch concurrency: scale op-sovereign-r1 for multi-user Ask AI.
+ * - workersMin=1 → keep one warm (no 3min cold for first ask)
+ * - workersMax=5 → concurrent Sovereign without one-GPU queue stampede
+ * - idleTimeout=600 → stay warm between asks; still scales toward min
+ *
+ * Usage: node scripts/ops-soft-launch-sovereign-capacity.mjs
+ */
+import fs from 'fs';
+
+const EP = 'sci7vw5ovb0xnd';
+const REST = 'https://rest.runpod.io/v1';
+
+function envLocal() {
+  const map = {};
+  try {
+    for (const line of fs.readFileSync('.env.local', 'utf8').split(/\r?\n/)) {
+      const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+      if (m) map[m[1]] = m[2].replace(/^["']|["']$/g, '').trim();
+    }
+  } catch {
+    /* ignore */
+  }
+  return map;
+}
+
+const local = envLocal();
+const key = local.RUNPOD_API_KEY || local.OLLAMA_API_KEY;
+if (!key) {
+  console.error('Need RUNPOD_API_KEY or OLLAMA_API_KEY in .env.local');
+  process.exit(2);
+}
+
+const body = {
+  workersMin: 1,
+  workersMax: 5,
+  idleTimeout: 600,
+};
+
+const get = await fetch(`${REST}/endpoints/${EP}`, {
+  headers: { Authorization: `Bearer ${key}` },
+});
+const before = await get.json();
+console.log(
+  'BEFORE',
+  JSON.stringify({
+    name: before.name,
+    workersMin: before.workersMin,
+    workersMax: before.workersMax,
+    idleTimeout: before.idleTimeout,
+  }),
+);
+
+const patch = await fetch(`${REST}/endpoints/${EP}`, {
+  method: 'PATCH',
+  headers: {
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(body),
+});
+const afterText = await patch.text();
+let after;
+try {
+  after = JSON.parse(afterText);
+} catch {
+  after = { raw: afterText };
+}
+console.log('PATCH', patch.status);
+console.log(
+  'AFTER',
+  JSON.stringify({
+    name: after.name,
+    workersMin: after.workersMin,
+    workersMax: after.workersMax,
+    idleTimeout: after.idleTimeout,
+  }),
+);
+
+if (!patch.ok) {
+  console.error(afterText.slice(0, 500));
+  process.exit(1);
+}
+
+// Probe warm path
+const t0 = Date.now();
+const models = await fetch(`https://api.runpod.ai/v2/${EP}/openai/v1/models`, {
+  headers: { Authorization: `Bearer ${key}` },
+  signal: AbortSignal.timeout(60_000),
+}).catch((e) => ({ ok: false, status: 0, err: e }));
+console.log(
+  'MODELS_PROBE',
+  JSON.stringify({
+    ok: !!models.ok,
+    status: models.status || 0,
+    ms: Date.now() - t0,
+  }),
+);
+
+console.log('SOFT_LAUNCH_CAPACITY_OK');


### PR DESCRIPTION
## Summary
- RunPod soft launch: workersMin=1, workersMax=5 (live patched) so multi-user Sovereign does not serialize on one GPU
- App wake budget 180s → 25s then Cloud Auto — customers are not stranded waiting minutes
- Docs + ops script for capacity posture

## Test plan
- [ ] Two accounts on Sovereign: second should not sit full 3 min; warm path or Cloud Auto within ~25s
- [ ] /models probe on sci7vw5ovb0xnd returns quickly while workersMin=1
- [ ] UI shows soft-launch warm status, not idle-was-$0 waking copy
