### PR TITLE
Restore Sovereign scale-to-zero (keep concurrency + fail-fast)

### DIFF
--- a/app/api/ai/sovereign/wake/route.ts
+++ b/app/api/ai/sovereign/wake/route.ts
@@ -1,7 +1,7 @@
 /**
  * POST /api/ai/sovereign/wake — wake-on-ask for OP-Hosted Sovereign PAYG.
- * Idle soft-launch: workersMin=1 keeps one warm worker; still PAYG beyond that.
- * This only spins additional capacity when the user selects Sovereign or is about to send.
+ * Idle: workersMin=0 ($0). Speculative wake spins a worker when the user
+ * selects Sovereign or is about to send. Does not touch portfolio payload.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuth } from 'firebase-admin/auth';
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
       waitedMs: result.waitedMs,
       probes: result.probes,
       provider,
-      idlePolicy: 'soft_launch_workersMin=1_workersMax=5',
+      idlePolicy: 'workersMin=0_workersMax=5',
     },
     {
       status: result.warm ? 200 : 503,

--- a/app/components/ai/AskAIModal.tsx
+++ b/app/components/ai/AskAIModal.tsx
@@ -362,7 +362,7 @@ export function AskAIModal({
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId
-              ? { ...m, content: 'Waking OP-Hosted Sovereign…' }
+              ? { ...m, content: 'Waking OP-Hosted Sovereign (idle GPU $0)…' }
               : m
           )
         );
@@ -690,7 +690,7 @@ export function AskAIModal({
                   {localModeActive
                     ? isOllamaClientDirectEnabled()
                       ? 'BYO laptop Ollama: bounded summary goes to your local node (not third-party cloud APIs). Attachments disabled in Phase 1.'
-                      : 'OP-Hosted Sovereign: soft-launch keeps a warm GPU ready. If wake is slow, Cloud Auto answers so you are never stranded.'
+                      : 'OP-Hosted Sovereign scales to zero when idle. Selecting Sovereign wakes a PAYG node; if wake is slow, Cloud Auto answers so you are never stranded.'
                     : 'Ask about your portfolio, markets, or investing. Your data stays local; only a summary is sent to the AI.'}
                 </p>
               )}
@@ -707,7 +707,7 @@ export function AskAIModal({
                     ? '● Localhost BYO · experimental'
                     : wakingSovereign
                       ? '● Waking Sovereign GPU…'
-                      : '● OP-Hosted Sovereign · soft-launch warm'}
+                      : '● OP-Hosted Sovereign · $0 idle · Cloud safety net'}
                 </p>
               )}
               {messages.map((m) => {

--- a/docs/command/sovereign-latency-contract-2026-08-04.md
+++ b/docs/command/sovereign-latency-contract-2026-08-04.md
@@ -56,7 +56,7 @@ First request after attaching the volume still populates the cache once. Later c
 | Sovereign selected | Speculative **wake-on-ask** (`POST /api/ai/sovereign/wake`) |
 | Sovereign Send + node warming | Poll `/models` up to **~25s** soft-launch; then Cloud Auto |
 | Wake budget exhausted / on-node error | Cloud Auto **safety net**; `X-Pocket-Inference: cloud_auto_fallback` |
-| Soft-launch capacity (2026-08-07) | `workersMin=1`, `workersMax=5`, `idleTimeout=600` — see `sovereign-soft-launch-capacity-2026-08-07.md` |
-| Idle GPU (post soft-launch target) | `workersMin=0` — **$0** when traffic allows |
+| Soft-launch capacity (2026-08-07 rev 2) | `workersMin=0`, `workersMax=5`, `idleTimeout=600` — scale to zero; concurrency when on |
+| Idle GPU | `workersMin=0` — **$0** when no workers |
 
 Vercel wake route `maxDuration` is **45s**. Chat remains longer for on-node complete + cloud fallback.

--- a/docs/command/sovereign-payg-mandate-lock-2026-08-04.md
+++ b/docs/command/sovereign-payg-mandate-lock-2026-08-04.md
@@ -13,7 +13,7 @@ date: 2026-08-04
 
 | Allowed | Forbidden |
 |---------|-----------|
-| RunPod **Serverless** soft-launch: `workersMin: 1`, `workersMax: 5`, `idleTimeout: 600` | Always-on **Pods**; `workersMax: 1` (serializes all users) |
+| RunPod **Serverless** `workersMin: 0`, `workersMax: 5`, `idleTimeout: 600` | Always-on warm (`workersMin: 1`); `workersMax: 1` (serializes all users) |
 | Per-second GPU while serving | Idle GPU burn / Pinggy-as-prod |
 | Prepaid wallet | “Customers download local models” |
 

--- a/docs/command/sovereign-soft-launch-capacity-2026-08-07.md
+++ b/docs/command/sovereign-soft-launch-capacity-2026-08-07.md
@@ -1,30 +1,30 @@
 ---
 id: OP-CMD-SOVEREIGN-SOFT-LAUNCH-CAPACITY-2026-08-07
-title: Soft-launch Sovereign capacity — multi-user fix
-status: LIVE
+title: Soft-launch Sovereign capacity — multi-user + scale-to-zero
+status: LIVE · SCALE_TO_ZERO
 date: 2026-08-07
+rev: 2
 endpoint: sci7vw5ovb0xnd (op-sovereign-r1)
 ---
 
-# Soft-launch capacity fix (CEO)
+# Soft-launch capacity (CEO lock)
 
-## Why leadership’s 180s budget was wrong for brand UX
+## Mandate
 
-`SOVEREIGN_WAKE_BUDGET_MS = 180s` was a **safety ceiling** for a single cold PAYG boot under `workersMax: 1` — not an accepted wait for 100 concurrent users. With one worker, N Sovereign asks **serialize**; each client burns the wake budget in a queue. That is a capacity bug, not a product feature.
+**Idle GPU ≈ $0 always** (`workersMin: 0`). Launch copy says scale-to-zero — keep that promise.  
+**Do not waste user time:** short wake budget → **Cloud Auto safety net**. Capacity for concurrency when *on*, not always-on warm standby.
 
-**Accepted product rule (unchanged):** customers must not wait ~minutes. Warm Sovereign ≈ cloud. Idle cost savings ≠ user-facing cold-start theatre.
+## Live RunPod posture (rev 2)
 
-## Live RunPod posture (2026-08-07)
+| Setting | Value | Why |
+|---------|-------|-----|
+| `workersMin` | **0** | Scale to zero — matches GTM / PAYG |
+| `workersMax` | **5** | Multi-user when scaled; no single-GPU queue stampede |
+| `idleTimeout` | **600** | Stay warm briefly after last ask, then scale toward 0 |
+| App wake budget | **25s** | Then Cloud Auto — never strand users for ~3 min |
 
-| Setting | Was (mandate lock) | Soft launch now |
-|---------|-------------------|-----------------|
-| `workersMin` | 0 | **1** (one warm worker — first ask should not cold-boot) |
-| `workersMax` | 1 | **5** (concurrent Sovereign without single-GPU stampede) |
-| `idleTimeout` | 600 | **600** |
-| App wake budget | 180s | **25s** then **Cloud Auto safety net** |
+Script: `node scripts/ops-soft-launch-sovereign-capacity.mjs` (min=0, max=5).
 
-Script: `node scripts/ops-soft-launch-sovereign-capacity.mjs`
+## Rejected
 
-## Post soft-launch
-
-Revert `workersMin → 0` when traffic is quiet **only if** volume-cached cold is proven &lt; ~15s. Keep `workersMax ≥ 3` for multi-user. Do not restore `workersMax: 1`.
+- Soft-launch `workersMin: 1` (~$27/day always-on) — conflicts with marketing + CEO cost gate.

--- a/scripts/ops-soft-launch-sovereign-capacity.mjs
+++ b/scripts/ops-soft-launch-sovereign-capacity.mjs
@@ -32,7 +32,7 @@ if (!key) {
 }
 
 const body = {
-  workersMin: 1,
+  workersMin: 0,
   workersMax: 5,
   idleTimeout: 600,
 };


### PR DESCRIPTION
﻿## Summary
- Revert workersMin to 0 (scale-to-zero / GTM promise) — live on RunPod
- Keep workersMax=5 for multi-user when scaled
- Keep 25s wake → Cloud Auto so cold path does not waste user time

## Test plan
- [ ] Endpoint shows workersMin=0, workersMax=5
- [ ] Cold Sovereign falls back to Cloud Auto within ~25s
