### PR TITLE
Ship Ask AI desk actions (guided prompts over chat-first)

### DIFF
--- a/app/components/ai/AskAIModal.tsx
+++ b/app/components/ai/AskAIModal.tsx
@@ -27,6 +27,11 @@ import {
   LOCAL_ASK_AI_SYSTEM_PREAMBLE,
   SOVEREIGN_WAKE_BUDGET_MS,
 } from '@/app/lib/ai/providers';
+import {
+  getDeskActions,
+  type DeskAction,
+} from '@/app/lib/ai/deskActions';
+import { useBrewinPilot } from '@/app/components/demo/BrewinPilotProvider';
 
 const ATTACHMENT_MAX_CHARS = 50000;
 
@@ -114,6 +119,8 @@ export function AskAIModal({
   isPaid = false,
 }: AskAIModalProps) {
   const { signInWithGoogle, loading: authLoading } = useAuth();
+  const { active: brewinPilotActive } = useBrewinPilot();
+  const deskActions = getDeskActions({ brewinPilot: brewinPilotActive });
   const [signInBusy, setSignInBusy] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -297,17 +304,17 @@ export function AskAIModal({
     void requestSovereignWake(providerMode);
   }, [open, user, localModeActive, providerMode, requestSovereignWake]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const text = input.trim();
-    if (!text || !user || isLoading) return;
+  const sendMessage = async (opts: { displayText: string; apiMessage: string }) => {
+    const displayText = opts.displayText.trim();
+    const apiMessage = opts.apiMessage.trim();
+    if (!apiMessage || !user || isLoading) return;
 
     setError(null);
     setInfoNotice(null);
     const userMessage: ChatMessage = {
       id: `user-${Date.now()}`,
       role: 'user',
-      content: text,
+      content: displayText || apiMessage,
     };
     setMessages((prev) => [...prev, userMessage]);
     setInput('');
@@ -340,7 +347,7 @@ export function AskAIModal({
             baseUrl,
             model,
             system,
-            user: text,
+            user: apiMessage,
             signal:
               typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal
                 ? (AbortSignal as any).timeout(120000)
@@ -386,7 +393,7 @@ export function AskAIModal({
           },
           signal: abort.signal,
           body: JSON.stringify({
-            message: text,
+            message: apiMessage,
             context: localModeActive
               ? truncatePortfolioContextForLocal(portfolioContext)
               : portfolioContext,
@@ -469,6 +476,22 @@ export function AskAIModal({
       setIsLoading(false);
       setWakingSovereign(false);
     }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text) return;
+    await sendMessage({ displayText: text, apiMessage: text });
+  };
+
+  const runDeskAction = (action: DeskAction) => {
+    if (!user || isLoading || attachmentProcessing) return;
+    trackEvent('ai_desk_action_click', {
+      action_id: action.id,
+      brewin_pilot: brewinPilotActive,
+    });
+    void sendMessage({ displayText: action.label, apiMessage: action.prompt });
   };
 
   const handleOverlayClick = (e: React.MouseEvent) => {
@@ -686,13 +709,68 @@ export function AskAIModal({
               }}
             >
               {messages.length === 0 && (
-                <p style={{ fontSize: '14px', color: 'hsl(var(--muted-foreground))', margin: 0 }}>
-                  {localModeActive
-                    ? isOllamaClientDirectEnabled()
-                      ? 'BYO laptop Ollama: bounded summary goes to your local node (not third-party cloud APIs). Attachments disabled in Phase 1.'
-                      : 'OP-Hosted Sovereign scales to zero when idle. Selecting Sovereign wakes a PAYG node; if wake is slow, Cloud Auto answers so you are never stranded.'
-                    : 'Ask about your portfolio, markets, or investing. Your data stays local; only a summary is sent to the AI.'}
-                </p>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                  <p style={{ fontSize: '14px', color: 'hsl(var(--muted-foreground))', margin: 0 }}>
+                    {localModeActive
+                      ? isOllamaClientDirectEnabled()
+                        ? 'BYO laptop Ollama: bounded summary goes to your local node (not third-party cloud APIs). Attachments disabled in Phase 1.'
+                        : 'OP-Hosted Sovereign scales to zero when idle. Selecting Sovereign wakes a PAYG node; if wake is slow, Cloud Auto answers so you are never stranded.'
+                      : 'Ask about your portfolio, markets, or investing. Your data stays local; only a summary is sent to the AI.'}
+                  </p>
+                  <div>
+                    <p
+                      style={{
+                        margin: '0 0 8px',
+                        fontSize: '11px',
+                        letterSpacing: '0.08em',
+                        textTransform: 'uppercase',
+                        color: 'var(--accent-warm, #f59e0b)',
+                      }}
+                    >
+                      Desk actions
+                    </p>
+                    <p style={{ margin: '0 0 10px', fontSize: '13px', color: 'hsl(var(--muted-foreground))' }}>
+                      Guided asks for desk work — or type freely below.
+                    </p>
+                    <div
+                      role="group"
+                      aria-label="Desk actions"
+                      style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}
+                    >
+                      {deskActions.map((action) => {
+                        const pinned =
+                          brewinPilotActive &&
+                          (action.id === 'concentration' || action.id === 'review_prep');
+                        return (
+                          <button
+                            key={action.id}
+                            type="button"
+                            title={action.shortHint}
+                            disabled={isLoading || attachmentProcessing}
+                            onClick={() => runDeskAction(action)}
+                            style={{
+                              padding: '8px 12px',
+                              borderRadius: '6px',
+                              border: pinned
+                                ? '1px solid var(--accent-warm, #f59e0b)'
+                                : '1px solid var(--border-subtle, hsl(var(--border)))',
+                              background: 'hsl(var(--background))',
+                              color: 'hsl(var(--foreground))',
+                              fontSize: '13px',
+                              fontWeight: pinned ? 600 : 500,
+                              cursor:
+                                isLoading || attachmentProcessing ? 'not-allowed' : 'pointer',
+                              opacity: isLoading || attachmentProcessing ? 0.6 : 1,
+                              textAlign: 'left',
+                            }}
+                          >
+                            {action.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
               )}
               {localModeActive && localAiEnabled && (
                 <p
@@ -787,6 +865,63 @@ export function AskAIModal({
                 onSequenceComplete={finishAttachmentTheater}
                 style={{ marginBottom: '10px' }}
               />
+              {messages.length > 0 && (
+                <div
+                  style={{
+                    marginBottom: '10px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '6px',
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: '10px',
+                      letterSpacing: '0.08em',
+                      textTransform: 'uppercase',
+                      color: 'hsl(var(--muted-foreground))',
+                    }}
+                  >
+                    More desk actions
+                  </span>
+                  <div
+                    role="group"
+                    aria-label="More desk actions"
+                    style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}
+                  >
+                    {deskActions.map((action) => {
+                      const pinned =
+                        brewinPilotActive &&
+                        (action.id === 'concentration' || action.id === 'review_prep');
+                      return (
+                        <button
+                          key={action.id}
+                          type="button"
+                          title={action.shortHint}
+                          disabled={isLoading || attachmentProcessing}
+                          onClick={() => runDeskAction(action)}
+                          style={{
+                            padding: '5px 10px',
+                            borderRadius: '4px',
+                            border: pinned
+                              ? '1px solid var(--accent-warm, #f59e0b)'
+                              : '1px solid var(--border-subtle, hsl(var(--border)))',
+                            background: 'transparent',
+                            color: 'hsl(var(--foreground))',
+                            fontSize: '12px',
+                            fontWeight: pinned ? 600 : 400,
+                            cursor:
+                              isLoading || attachmentProcessing ? 'not-allowed' : 'pointer',
+                            opacity: isLoading || attachmentProcessing ? 0.6 : 1,
+                          }}
+                        >
+                          {action.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
               <div style={{ marginBottom: '8px', display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
                 <input
                   ref={fileInputRef}
@@ -845,7 +980,7 @@ export function AskAIModal({
                 <textarea
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
-                  placeholder="Ask about your portfolio or markets..."
+                  placeholder="Or type freely…"
                   rows={1}
                   disabled={isLoading || attachmentProcessing}
                   style={{

--- a/app/lib/ai/deskActions.ts
+++ b/app/lib/ai/deskActions.ts
@@ -1,0 +1,89 @@
+/**
+ * Pocket Ask AI — curated desk actions (guided prompts over raw chat).
+ * Same inference path: buildPortfolioContext → /api/ai/chat.
+ * Claim-safe: conversation points only; no personal tax/advice.
+ */
+
+export type DeskActionId =
+  | 'concentration'
+  | 'allocation'
+  | 'risk_narrative'
+  | 'review_prep'
+  | 'what_changed';
+
+export type DeskAction = {
+  id: DeskActionId;
+  label: string;
+  shortHint: string;
+  /** Full prompt sent to /api/ai/chat (user bubble shows `label`). */
+  prompt: string;
+};
+
+const PROMPT_GUARD =
+  'Use only the portfolio context provided with this request. Reply in clear Markdown (short sections, bullets). Do not give personal investment, tax, or regulated advice — frame outputs as analytical observations and conversation points for a human advisor review. If context is thin, say what is missing instead of inventing numbers.';
+
+export const DESK_ACTIONS: readonly DeskAction[] = [
+  {
+    id: 'concentration',
+    label: 'Concentration',
+    shortHint: 'Single-name and top-holding risk',
+    prompt: `${PROMPT_GUARD}
+
+Task: Concentration review.
+From the portfolio context, identify the largest holdings and any material single-name or sector concentration. Quantify approximate weights where the context supports it. Flag conversation points an advisor might raise before a review (e.g. liquidity event overhang, block-sale considerations) without recommending a trade.`,
+  },
+  {
+    id: 'allocation',
+    label: 'Allocation',
+    shortHint: 'Asset and region mix',
+    prompt: `${PROMPT_GUARD}
+
+Task: Allocation snapshot.
+Summarise how the book is allocated across asset classes, regions, and any other mix dimensions present in the context. Call out what is driving the overall shape of the portfolio. Keep it desk-ready and concise.`,
+  },
+  {
+    id: 'risk_narrative',
+    label: 'Risk narrative',
+    shortHint: 'What could go wrong',
+    prompt: `${PROMPT_GUARD}
+
+Task: Risk narrative for a client review.
+In plain language, describe the main risks visible in this book (market, concentration, currency, liquidity, or structural). Prioritise highest-signal risks. End with 3–5 conversation points — not product recommendations.`,
+  },
+  {
+    id: 'review_prep',
+    label: 'Review prep',
+    shortHint: 'Talking points for a meeting',
+    prompt: `${PROMPT_GUARD}
+
+Task: Client review prep.
+Produce 5–7 talking points an advisor could use in an upcoming review meeting, grounded only in the portfolio context. Order by importance. Each point: one sentence observation + why it matters in the room. No personal advice; no tax.`,
+  },
+  {
+    id: 'what_changed',
+    label: 'What stands out',
+    shortHint: 'Highest-signal quirks',
+    prompt: `${PROMPT_GUARD}
+
+Task: What stands out.
+Scan the bounded portfolio summary for the highest-signal quirks, imbalances, or notable patterns. List 4–6 observations ranked by how likely they are to matter in a desk conversation. Skip generic market commentary unless tied to this book.`,
+  },
+] as const;
+
+/** Brewin pilot: pin concentration + review_prep to the front of the chip row. */
+const BREWIN_PINNED: readonly DeskActionId[] = ['concentration', 'review_prep'];
+
+export function getDeskActions(options?: { brewinPilot?: boolean }): DeskAction[] {
+  const list = [...DESK_ACTIONS];
+  if (!options?.brewinPilot) return list;
+  const pinned = new Set(BREWIN_PINNED);
+  const head = BREWIN_PINNED.map((id) => list.find((a) => a.id === id)).filter(
+    (a): a is DeskAction => !!a
+  );
+  const tail = list.filter((a) => !pinned.has(a.id));
+  return [...head, ...tail];
+}
+
+export function getDeskAction(id: DeskActionId): DeskAction | undefined {
+  return DESK_ACTIONS.find((a) => a.id === id);
+}


### PR DESCRIPTION
﻿## Summary
- Adds curated Pocket Ask AI Desk actions (Concentration, Allocation, Risk narrative, Review prep, What stands out) that auto-send claim-safe structured prompts over the existing bounded buildPortfolioContext to /api/ai/chat path.
- Brewin pilot pins Concentration + Review prep. Analytics: ai_desk_action_click.
- Responds to RBC Brewin Dolphin desk feedback on advisor prompt fluency (chips first, not multi-agent runtime).

## Test plan
- [ ] Open Ask AI signed-in empty state — Desk actions chips visible
- [ ] Click Concentration — user bubble shows label; stream returns
- [ ] Mid-session More desk actions still works
- [ ] /demo/brewin (allowlisted) pins Concentration + Review prep with amber border
- [ ] Free-text chat still works
